### PR TITLE
Add member data scrubbing to admin data dump

### DIFF
--- a/blowcomotion/tests/test_dump_data_view.py
+++ b/blowcomotion/tests/test_dump_data_view.py
@@ -162,6 +162,11 @@ class DumpDataViewTests(TestCase):
         self.assertEqual(fields['bio'], 'Real bio text')
         self.assertEqual(fields['notes'], 'Real notes text')
 
+        # Users and site settings should never be exported (even when including real member data)
+        dumped_models = {item.get('model') for item in data}
+        self.assertNotIn('auth.user', dumped_models)
+        self.assertNotIn('blowcomotion.sitesettings', dumped_models)
+
     def test_fake_members_after_dependencies(self):
         """Test that dumpdata orders member records after instrument records (FK dependency ordering)"""
         self.client.login(username='admin', password='testpass123')

--- a/blowcomotion/tests/test_dump_data_view.py
+++ b/blowcomotion/tests/test_dump_data_view.py
@@ -73,11 +73,10 @@ class DumpDataViewTests(TestCase):
         self.assertEqual(response.status_code, 302)  # Redirects to login
         
         # Try with regular user - also redirects since they lack admin access
-        regular_user = User.objects.create_user(
+        User.objects.create_user(
             username='regular',
             password='testpass123'
         )
-        self.client.login(username='regular', password='testpass123')
         response = self.client.get(reverse('dump_data'))
         # Regular users without admin permissions are redirected
         self.assertIn(response.status_code, [302, 403])

--- a/blowcomotion/tests/test_dump_data_view.py
+++ b/blowcomotion/tests/test_dump_data_view.py
@@ -207,8 +207,8 @@ class DumpDataViewTests(TestCase):
         names2 = [(m['fields']['first_name'], m['fields']['last_name']) for m in members2]
         self.assertEqual(names1, names2, "Generated fake names should be consistent")
 
-    def test_preserves_all_member_fields(self):
-        """Test that all member fields are included in scrubbed output"""
+    def test_preserves_expected_member_fields(self):
+        """Test that the expected member fields are included in scrubbed output"""
         self.client.login(username='admin', password='testpass123')
         response = self.client.get(reverse('dump_data'))
         

--- a/blowcomotion/tests/test_dump_data_view.py
+++ b/blowcomotion/tests/test_dump_data_view.py
@@ -72,13 +72,15 @@ class DumpDataViewTests(TestCase):
         response = self.client.get(reverse('dump_data'))
         self.assertEqual(response.status_code, 302)  # Redirects to login
         
-        # Try with regular user - also redirects since they lack admin access
+        # Try with regular (staff) user - should be forbidden or redirected
         User.objects.create_user(
             username='regular',
-            password='testpass123'
+            password='testpass123',
+            is_staff=True,
         )
+        self.client.login(username='regular', password='testpass123')
         response = self.client.get(reverse('dump_data'))
-        # Regular users without admin permissions are redirected
+        # Non-superuser staff are redirected by admin middleware or get 403 from view
         self.assertIn(response.status_code, [302, 403])
         
         # Superuser should have access
@@ -98,7 +100,7 @@ class DumpDataViewTests(TestCase):
         
         # Find member records in the dump
         member_records = [item for item in data if item.get('model') == 'blowcomotion.member']
-        self.assertEqual(len(member_records), 2, "Should have 2 fake member records")
+        self.assertEqual(len(member_records), 2, "Should have 2 scrubbed member records")
         
         # Check that member1's data is scrubbed
         member1_record = next((r for r in member_records if r['pk'] == self.member1.pk), None)
@@ -161,7 +163,7 @@ class DumpDataViewTests(TestCase):
         self.assertEqual(fields['notes'], 'Real notes text')
 
     def test_fake_members_after_dependencies(self):
-        """Test that fake members are inserted after instrument dependencies"""
+        """Test that dumpdata orders member records after instrument records (FK dependency ordering)"""
         self.client.login(username='admin', password='testpass123')
         response = self.client.get(reverse('dump_data'))
         
@@ -178,7 +180,7 @@ class DumpDataViewTests(TestCase):
             self.assertGreater(
                 first_member_index, 
                 last_instrument_index,
-                "Fake members should be inserted after instruments to satisfy FK constraints"
+                "Member records should be serialized after instruments to satisfy FK constraints"
             )
 
     def test_deterministic_ordering(self):
@@ -204,7 +206,7 @@ class DumpDataViewTests(TestCase):
         # Names should be consistent
         names1 = [(m['fields']['first_name'], m['fields']['last_name']) for m in members1]
         names2 = [(m['fields']['first_name'], m['fields']['last_name']) for m in members2]
-        self.assertEqual(names1, names2, "Generated fake names should be consistent")
+        self.assertEqual(names1, names2, "Scrubbed member names should be deterministic")
 
     def test_preserves_expected_member_fields(self):
         """Test that the expected member fields are included in scrubbed output"""

--- a/blowcomotion/tests/test_dump_data_view.py
+++ b/blowcomotion/tests/test_dump_data_view.py
@@ -68,9 +68,9 @@ class DumpDataViewTests(TestCase):
 
     def test_requires_superuser(self):
         """Test that dump_data requires superuser authentication"""
-        # Try without authentication - admin views redirect to login
+        # Try without authentication - may redirect to login or return forbidden
         response = self.client.get(reverse('dump_data'))
-        self.assertEqual(response.status_code, 302)  # Redirects to login
+        self.assertIn(response.status_code, [302, 403])  # Redirect to login or forbidden
         
         # Try with regular (staff) user - should be forbidden or redirected
         User.objects.create_user(

--- a/blowcomotion/tests/test_dump_data_view.py
+++ b/blowcomotion/tests/test_dump_data_view.py
@@ -240,3 +240,22 @@ class DumpDataViewTests(TestCase):
                     fields, 
                     f"Field '{field_name}' should be included in scrubbed member data"
                 )
+
+    def test_user_fks_are_cleared(self):
+        """Test that user FK fields are nulled to prevent dangling references"""
+        self.client.login(username='admin', password='testpass123')
+        response = self.client.get(reverse('dump_data'))
+        
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        
+        # Check that any user FK fields in the dump are nulled
+        user_fk_field_names = {'uploaded_by_user', 'user', 'locked_by', 'owner'}
+        for item in data:
+            fields = item.get('fields', {})
+            for field_name in user_fk_field_names:
+                if field_name in fields:
+                    self.assertIsNone(
+                        fields[field_name],
+                        f"User FK field '{field_name}' in {item.get('model')} should be null"
+                    )

--- a/blowcomotion/tests/test_dump_data_view.py
+++ b/blowcomotion/tests/test_dump_data_view.py
@@ -1,0 +1,236 @@
+"""
+Unit tests for admin dump_data view.
+"""
+
+import json
+
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from blowcomotion.models import Instrument, Member, Section
+
+
+class DumpDataViewTests(TestCase):
+    """Test cases for dump_data admin view with member data scrubbing"""
+
+    def setUp(self):
+        """Set up test data"""
+        self.client = Client()
+        
+        # Create superuser for authentication
+        self.superuser = User.objects.create_superuser(
+            username='admin',
+            email='admin@example.com',
+            password='testpass123'
+        )
+        
+        # Create test section and instrument for FK relationships
+        self.section = Section.objects.create(name="Test Section")
+        self.instrument = Instrument.objects.create(
+            name="Test Instrument",
+            section=self.section
+        )
+        
+        # Create test members with various fields
+        self.member1 = Member.objects.create(
+            first_name="John",
+            last_name="Doe",
+            preferred_name="Johnny",
+            email="john.doe@example.com",
+            phone="555-1234",
+            address="123 Real St",
+            city="Austin",
+            state="TX",
+            zip_code="78701",
+            country="USA",
+            primary_instrument=self.instrument,
+            birth_month=5,
+            birth_day=15,
+            birth_year=1990,
+            bio="Real bio text",
+            notes="Real notes text",
+            inspired_by="Real inspiration",
+            emergency_contact="Jane Doe 555-5678",
+            is_active=True,
+            instructor=False,
+            board_member=True,
+            renting=False
+        )
+        
+        self.member2 = Member.objects.create(
+            first_name="Jane",
+            last_name="Smith",
+            email="jane.smith@example.com",
+            primary_instrument=self.instrument,
+            is_active=False
+        )
+
+    def test_requires_superuser(self):
+        """Test that dump_data requires superuser authentication"""
+        # Try without authentication - admin views redirect to login
+        response = self.client.get(reverse('dump_data'))
+        self.assertEqual(response.status_code, 302)  # Redirects to login
+        
+        # Try with regular user - also redirects since they lack admin access
+        regular_user = User.objects.create_user(
+            username='regular',
+            password='testpass123'
+        )
+        self.client.login(username='regular', password='testpass123')
+        response = self.client.get(reverse('dump_data'))
+        # Regular users without admin permissions are redirected
+        self.assertIn(response.status_code, [302, 403])
+        
+        # Superuser should have access
+        self.client.login(username='admin', password='testpass123')
+        response = self.client.get(reverse('dump_data'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_default_scrubs_member_data(self):
+        """Test that member data is scrubbed by default"""
+        self.client.login(username='admin', password='testpass123')
+        response = self.client.get(reverse('dump_data'))
+        
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/json')
+        
+        data = json.loads(response.content)
+        
+        # Find member records in the dump
+        member_records = [item for item in data if item.get('model') == 'blowcomotion.member']
+        self.assertEqual(len(member_records), 2, "Should have 2 fake member records")
+        
+        # Check that member1's data is scrubbed
+        member1_record = next((r for r in member_records if r['pk'] == self.member1.pk), None)
+        self.assertIsNotNone(member1_record)
+        fields = member1_record['fields']
+        
+        # Verify scrubbed fields
+        self.assertEqual(fields['first_name'], 'FirstName1')
+        self.assertEqual(fields['last_name'], 'LastName1')
+        self.assertEqual(fields['preferred_name'], 'Preferred1')
+        self.assertEqual(fields['email'], 'member1@example.com')
+        self.assertEqual(fields['phone'], '555-0001')
+        self.assertEqual(fields['address'], '1 Main Street')
+        self.assertEqual(fields['city'], 'Austin')
+        self.assertEqual(fields['state'], 'TX')
+        self.assertEqual(fields['zip_code'], '00001')
+        self.assertEqual(fields['country'], 'USA')
+        self.assertEqual(fields['bio'], 'Scrubbed for privacy')
+        self.assertEqual(fields['notes'], 'Scrubbed for privacy')
+        self.assertEqual(fields['inspired_by'], 'Scrubbed for privacy')
+        self.assertEqual(fields['emergency_contact'], 'Emergency Contact 1')
+        
+        # Verify preserved fields
+        self.assertEqual(fields['primary_instrument'], self.instrument.pk)
+        self.assertEqual(fields['birth_month'], 5)
+        self.assertEqual(fields['birth_day'], 15)
+        self.assertEqual(fields['birth_year'], 1990)
+        self.assertTrue(fields['is_active'])
+        self.assertFalse(fields['instructor'])
+        self.assertTrue(fields['board_member'])
+        self.assertFalse(fields['renting'])
+
+    def test_include_real_data_parameter(self):
+        """Test that ?include_real_data=true returns actual member data"""
+        self.client.login(username='admin', password='testpass123')
+        response = self.client.get(reverse('dump_data') + '?include_real_data=true')
+        
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        
+        # Find member records in the dump
+        member_records = [item for item in data if item.get('model') == 'blowcomotion.member']
+        self.assertEqual(len(member_records), 2, "Should have 2 real member records")
+        
+        # Check that member1's real data is included
+        member1_record = next((r for r in member_records if r['pk'] == self.member1.pk), None)
+        self.assertIsNotNone(member1_record)
+        fields = member1_record['fields']
+        
+        # Verify real data is present
+        self.assertEqual(fields['first_name'], 'John')
+        self.assertEqual(fields['last_name'], 'Doe')
+        self.assertEqual(fields['preferred_name'], 'Johnny')
+        self.assertEqual(fields['email'], 'john.doe@example.com')
+        self.assertEqual(fields['phone'], '555-1234')
+        self.assertEqual(fields['address'], '123 Real St')
+        self.assertEqual(fields['city'], 'Austin')
+        self.assertEqual(fields['state'], 'TX')
+        self.assertEqual(fields['bio'], 'Real bio text')
+        self.assertEqual(fields['notes'], 'Real notes text')
+
+    def test_fake_members_after_dependencies(self):
+        """Test that fake members are inserted after instrument dependencies"""
+        self.client.login(username='admin', password='testpass123')
+        response = self.client.get(reverse('dump_data'))
+        
+        data = json.loads(response.content)
+        
+        # Find indices
+        instrument_indices = [i for i, item in enumerate(data) if item.get('model') == 'blowcomotion.instrument']
+        member_indices = [i for i, item in enumerate(data) if item.get('model') == 'blowcomotion.member']
+        
+        if instrument_indices and member_indices:
+            # Members should come after instruments
+            last_instrument_index = max(instrument_indices)
+            first_member_index = min(member_indices)
+            self.assertGreater(
+                first_member_index, 
+                last_instrument_index,
+                "Fake members should be inserted after instruments to satisfy FK constraints"
+            )
+
+    def test_deterministic_ordering(self):
+        """Test that member ordering is deterministic across multiple dumps"""
+        self.client.login(username='admin', password='testpass123')
+        
+        # Get two dumps
+        response1 = self.client.get(reverse('dump_data'))
+        response2 = self.client.get(reverse('dump_data'))
+        
+        data1 = json.loads(response1.content)
+        data2 = json.loads(response2.content)
+        
+        # Extract member records
+        members1 = [item for item in data1 if item.get('model') == 'blowcomotion.member']
+        members2 = [item for item in data2 if item.get('model') == 'blowcomotion.member']
+        
+        # PKs should be in the same order
+        pks1 = [m['pk'] for m in members1]
+        pks2 = [m['pk'] for m in members2]
+        self.assertEqual(pks1, pks2, "Member PKs should be in consistent order")
+        
+        # Names should be consistent
+        names1 = [(m['fields']['first_name'], m['fields']['last_name']) for m in members1]
+        names2 = [(m['fields']['first_name'], m['fields']['last_name']) for m in members2]
+        self.assertEqual(names1, names2, "Generated fake names should be consistent")
+
+    def test_preserves_all_member_fields(self):
+        """Test that all member fields are included in scrubbed output"""
+        self.client.login(username='admin', password='testpass123')
+        response = self.client.get(reverse('dump_data'))
+        
+        data = json.loads(response.content)
+        member_records = [item for item in data if item.get('model') == 'blowcomotion.member']
+        
+        if member_records:
+            fields = member_records[0]['fields']
+            
+            # Check all expected fields are present
+            expected_fields = [
+                'first_name', 'last_name', 'preferred_name', 'primary_instrument',
+                'birth_month', 'birth_day', 'birth_year', 'email', 'phone',
+                'address', 'city', 'state', 'zip_code', 'country',
+                'emergency_contact', 'inspired_by', 'is_active', 'instructor',
+                'board_member', 'join_date', 'last_seen', 'separation_date',
+                'reactivated_date', 'bio', 'notes', 'renting'
+            ]
+            
+            for field_name in expected_fields:
+                self.assertIn(
+                    field_name, 
+                    fields, 
+                    f"Field '{field_name}' should be included in scrubbed member data"
+                )

--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -873,7 +873,7 @@ def dump_data(request):
         # Scrub member data - generate fake members if not including real data
         if not include_real_data:
             # Get real members to preserve structure and relationships
-            real_members = Member.objects.all()
+            real_members = Member.objects.order_by('pk')
             fake_members = []
             
             for idx, member in enumerate(real_members, start=1):
@@ -903,13 +903,22 @@ def dump_data(request):
                         "board_member": member.board_member,
                         "join_date": str(member.join_date) if member.join_date else None,
                         "last_seen": str(member.last_seen) if member.last_seen else None,
+                        "separation_date": str(member.separation_date) if member.separation_date else None,
+                        "reactivated_date": str(member.reactivated_date) if member.reactivated_date else None,
+                        "bio": "Scrubbed for privacy" if member.bio else None,
+                        "notes": "Scrubbed for privacy" if member.notes else None,
                         "renting": member.renting,
                     }
                 }
                 fake_members.append(fake_member)
             
-            # Add fake members to data
-            data.extend(fake_members)
+            # Insert fake members after dependency targets (e.g., instruments/images) so FK constraints
+            # are satisfied when loading fixtures.
+            insert_at = 0
+            for i, item in enumerate(data):
+                if item.get("model") in {"blowcomotion.instrument", "blowcomotion.customimage"}:
+                    insert_at = i + 1
+            data[insert_at:insert_at] = fake_members
             logger.info(f"Generated {len(fake_members)} fake members for scrubbed data dump")
 
         logger.info(f"Data dump completed successfully by user {request.user.username}")

--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -835,7 +835,7 @@ def dump_data(request):
     include_real_data = request.GET.get('include_real_data', 'false').lower() == 'true'
 
     # Base arguments for `dumpdata`
-    # Always exclude auth users and site settings (contain plaintext passwords)
+    # Always exclude auth users and site settings (may contain credentials and other sensitive data)
     base_args = [
         '--natural-primary', '--natural-foreign', '--indent', '2',
         '-e', 'contenttypes', '-e', 'auth.permission', 
@@ -909,7 +909,10 @@ def dump_data(request):
 
         logger.info(f"Data dump completed successfully by user {request.user.username}")
         # Return the data as a JSON response with pretty formatting
-        return JsonResponse(data, safe=False, json_dumps_params={'indent': 2})
+        # Mark as non-cacheable to prevent sensitive data from being stored by browsers/proxies
+        response = JsonResponse(data, safe=False, json_dumps_params={'indent': 2})
+        response['Cache-Control'] = 'no-store'
+        return response
 
     except Exception as e:
         logger.error(f"Error during data dump by user {request.user.username}: {str(e)}")

--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -829,21 +829,32 @@ def _process_form_submission(request, form_type, form_data, submission_model):
 def dump_data(request):
     # Create an in-memory string buffer to capture the output
     output = StringIO()
+    
+    # Check if the user wants real member data (default is scrubbed for privacy)
+    # Pass ?include_real_data=true to get actual member information
+    include_real_data = request.GET.get('include_real_data', 'false').lower() == 'true'
 
-    # Arguments for `dumpdata`
-    args = [
+    # Base arguments for `dumpdata`
+    base_args = [
         '--natural-primary', '--natural-foreign', '--indent', '2',
         '-e', 'contenttypes', '-e', 'auth.permission', 
         '-e', 'wagtailcore.groupcollectionpermission', '-e', 'wagtailcore.grouppagepermission', '-e', 'wagtailcore.referenceindex', 
         '-e', 'wagtailimages.rendition', '-e', 'sessions', '-e', 'wagtailsearch', '-e', 'wagtailcore.pagelogentry', '-e', 'wagtailcore.revision', '-e', 'wagtailcore.taskstate', '-e', 'wagtailcore.workflowstate', '-e', 'wagtailcore.comment',
     ]
+    
+    # Exclude Member table if scrubbing data (will be replaced with fake data)
+    if not include_real_data:
+        base_args.extend(['-e', 'blowcomotion.Member'])
+    
+    args = base_args
+    
     # Check if the user is superuser
     if not request.user.is_superuser:
         logger.warning(f"Unauthorized access attempt to dump_data by user {request.user.username}")
         return JsonResponse({'error': 'You must be a superuser to access this feature'}, status=403)
 
     try:
-        logger.info(f"Starting data dump by user {request.user.username}")
+        logger.info(f"Starting data dump by user {request.user.username} (include_real_data={include_real_data})")
         # Use call_command to execute `dumpdata` and capture the output in the StringIO buffer
         call_command('dumpdata', *args, stdout=output)
 
@@ -858,6 +869,48 @@ def dump_data(request):
                     item['fields']['latest_revision'] = None
                 if 'live_revision' in item['fields']:
                     item['fields']['live_revision'] = None
+
+        # Scrub member data - generate fake members if not including real data
+        if not include_real_data:
+            # Get real members to preserve structure and relationships
+            real_members = Member.objects.all()
+            fake_members = []
+            
+            for idx, member in enumerate(real_members, start=1):
+                # Create fake member data preserving only non-sensitive fields
+                fake_member = {
+                    "model": "blowcomotion.member",
+                    "pk": member.pk,
+                    "fields": {
+                        "first_name": f"FirstName{idx}",
+                        "last_name": f"LastName{idx}",
+                        "preferred_name": f"Preferred{idx}" if member.preferred_name else None,
+                        "primary_instrument": member.primary_instrument_id,
+                        "birth_month": member.birth_month,
+                        "birth_day": member.birth_day,
+                        "birth_year": member.birth_year,
+                        "email": f"member{idx}@example.com" if member.email else None,
+                        "phone": f"555-{idx:04d}" if member.phone else None,
+                        "address": f"{idx} Main Street" if member.address else None,
+                        "city": "Austin" if member.city else None,
+                        "state": "TX" if member.state else None,
+                        "zip_code": f"{idx:05d}" if member.zip_code else None,
+                        "country": "USA" if member.country else None,
+                        "emergency_contact": f"Emergency Contact {idx}" if member.emergency_contact else None,
+                        "inspired_by": "Scrubbed for privacy" if member.inspired_by else None,
+                        "is_active": member.is_active,
+                        "instructor": member.instructor,
+                        "board_member": member.board_member,
+                        "join_date": str(member.join_date) if member.join_date else None,
+                        "last_seen": str(member.last_seen) if member.last_seen else None,
+                        "renting": member.renting,
+                    }
+                }
+                fake_members.append(fake_member)
+            
+            # Add fake members to data
+            data.extend(fake_members)
+            logger.info(f"Generated {len(fake_members)} fake members for scrubbed data dump")
 
         logger.info(f"Data dump completed successfully by user {request.user.username}")
         # Return the data as a JSON response with pretty formatting

--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -842,7 +842,10 @@ def dump_data(request):
         '-e', 'wagtailimages.rendition', '-e', 'sessions', '-e', 'wagtailsearch', '-e', 'wagtailcore.pagelogentry', '-e', 'wagtailcore.revision', '-e', 'wagtailcore.taskstate', '-e', 'wagtailcore.workflowstate', '-e', 'wagtailcore.comment',
     ]
     
-    args = base_args
+    # For scrubbed dumps, also exclude auth users and site settings that contain passwords
+    args = list(base_args)
+    if not include_real_data:
+        args += ['-e', 'auth.user', '-e', 'blowcomotion.sitesettings']
     
     # Check if the user is superuser
     if not request.user.is_superuser:
@@ -896,6 +899,10 @@ def dump_data(request):
                     fields['inspired_by'] = 'Scrubbed for privacy' if fields.get('inspired_by') else None
                     fields['bio'] = 'Scrubbed for privacy' if fields.get('bio') else None
                     fields['notes'] = 'Scrubbed for privacy' if fields.get('notes') else None
+                    # Scrub GigoGig integration identifiers and member photos
+                    fields['gigomatic_username'] = None
+                    fields['gigomatic_id'] = None
+                    fields['image'] = None
                     
                     scrubbed_count += 1
             

--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -868,6 +868,13 @@ def dump_data(request):
                 if 'live_revision' in item['fields']:
                     item['fields']['live_revision'] = None
 
+        # Clear user FKs that would otherwise reference excluded `auth.user` records
+        # (e.g. blowcomotion.CustomImage.uploaded_by_user)
+        for item in data:
+            fields = item.get('fields')
+            if fields and 'uploaded_by_user' in fields:
+                fields['uploaded_by_user'] = None
+
         # Scrub member data in-place if not including real data
         # This preserves Django's dependency ordering while scrubbing sensitive information
         if not include_real_data:

--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -842,10 +842,6 @@ def dump_data(request):
         '-e', 'wagtailimages.rendition', '-e', 'sessions', '-e', 'wagtailsearch', '-e', 'wagtailcore.pagelogentry', '-e', 'wagtailcore.revision', '-e', 'wagtailcore.taskstate', '-e', 'wagtailcore.workflowstate', '-e', 'wagtailcore.comment',
     ]
     
-    # Exclude Member table if scrubbing data (will be replaced with fake data)
-    if not include_real_data:
-        base_args.extend(['-e', 'blowcomotion.Member'])
-    
     args = base_args
     
     # Check if the user is superuser
@@ -870,56 +866,40 @@ def dump_data(request):
                 if 'live_revision' in item['fields']:
                     item['fields']['live_revision'] = None
 
-        # Scrub member data - generate fake members if not including real data
+        # Scrub member data in-place if not including real data
+        # This preserves Django's dependency ordering while scrubbing sensitive information
         if not include_real_data:
-            # Get real members to preserve structure and relationships
-            real_members = Member.objects.order_by('pk')
-            fake_members = []
+            # Build a mapping of member PKs to sequential indices for consistent fake data
+            member_pks = sorted([item['pk'] for item in data if item.get('model') == 'blowcomotion.member'])
+            member_pk_to_index = {pk: idx + 1 for idx, pk in enumerate(member_pks)}
             
-            for idx, member in enumerate(real_members, start=1):
-                # Create fake member data preserving only non-sensitive fields
-                fake_member = {
-                    "model": "blowcomotion.member",
-                    "pk": member.pk,
-                    "fields": {
-                        "first_name": f"FirstName{idx}",
-                        "last_name": f"LastName{idx}",
-                        "preferred_name": f"Preferred{idx}" if member.preferred_name else None,
-                        "primary_instrument": member.primary_instrument_id,
-                        "birth_month": member.birth_month,
-                        "birth_day": member.birth_day,
-                        "birth_year": member.birth_year,
-                        "email": f"member{idx}@example.com" if member.email else None,
-                        "phone": f"555-{idx:04d}" if member.phone else None,
-                        "address": f"{idx} Main Street" if member.address else None,
-                        "city": "Austin" if member.city else None,
-                        "state": "TX" if member.state else None,
-                        "zip_code": f"{idx:05d}" if member.zip_code else None,
-                        "country": "USA" if member.country else None,
-                        "emergency_contact": f"Emergency Contact {idx}" if member.emergency_contact else None,
-                        "inspired_by": "Scrubbed for privacy" if member.inspired_by else None,
-                        "is_active": member.is_active,
-                        "instructor": member.instructor,
-                        "board_member": member.board_member,
-                        "join_date": str(member.join_date) if member.join_date else None,
-                        "last_seen": str(member.last_seen) if member.last_seen else None,
-                        "separation_date": str(member.separation_date) if member.separation_date else None,
-                        "reactivated_date": str(member.reactivated_date) if member.reactivated_date else None,
-                        "bio": "Scrubbed for privacy" if member.bio else None,
-                        "notes": "Scrubbed for privacy" if member.notes else None,
-                        "renting": member.renting,
-                    }
-                }
-                fake_members.append(fake_member)
+            scrubbed_count = 0
+            # Scrub member records in-place
+            for item in data:
+                if item.get('model') == 'blowcomotion.member':
+                    member_pk = item['pk']
+                    idx = member_pk_to_index[member_pk]
+                    fields = item['fields']
+                    
+                    # Scrub sensitive fields while preserving structure and non-sensitive data
+                    fields['first_name'] = f'FirstName{idx}'
+                    fields['last_name'] = f'LastName{idx}'
+                    fields['preferred_name'] = f'Preferred{idx}' if fields.get('preferred_name') else None
+                    fields['email'] = f'member{idx}@example.com' if fields.get('email') else None
+                    fields['phone'] = f'555-{idx:04d}' if fields.get('phone') else None
+                    fields['address'] = f'{idx} Main Street' if fields.get('address') else None
+                    fields['city'] = 'Austin' if fields.get('city') else None
+                    fields['state'] = 'TX' if fields.get('state') else None
+                    fields['zip_code'] = f'{idx:05d}' if fields.get('zip_code') else None
+                    fields['country'] = 'USA' if fields.get('country') else None
+                    fields['emergency_contact'] = f'Emergency Contact {idx}' if fields.get('emergency_contact') else None
+                    fields['inspired_by'] = 'Scrubbed for privacy' if fields.get('inspired_by') else None
+                    fields['bio'] = 'Scrubbed for privacy' if fields.get('bio') else None
+                    fields['notes'] = 'Scrubbed for privacy' if fields.get('notes') else None
+                    
+                    scrubbed_count += 1
             
-            # Insert fake members after dependency targets (e.g., instruments/images) so FK constraints
-            # are satisfied when loading fixtures.
-            insert_at = 0
-            for i, item in enumerate(data):
-                if item.get("model") in {"blowcomotion.instrument", "blowcomotion.customimage"}:
-                    insert_at = i + 1
-            data[insert_at:insert_at] = fake_members
-            logger.info(f"Generated {len(fake_members)} fake members for scrubbed data dump")
+            logger.info(f'Scrubbed {scrubbed_count} member records in data dump')
 
         logger.info(f"Data dump completed successfully by user {request.user.username}")
         # Return the data as a JSON response with pretty formatting

--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -835,17 +835,16 @@ def dump_data(request):
     include_real_data = request.GET.get('include_real_data', 'false').lower() == 'true'
 
     # Base arguments for `dumpdata`
+    # Always exclude auth users and site settings (contain plaintext passwords)
     base_args = [
         '--natural-primary', '--natural-foreign', '--indent', '2',
         '-e', 'contenttypes', '-e', 'auth.permission', 
         '-e', 'wagtailcore.groupcollectionpermission', '-e', 'wagtailcore.grouppagepermission', '-e', 'wagtailcore.referenceindex', 
         '-e', 'wagtailimages.rendition', '-e', 'sessions', '-e', 'wagtailsearch', '-e', 'wagtailcore.pagelogentry', '-e', 'wagtailcore.revision', '-e', 'wagtailcore.taskstate', '-e', 'wagtailcore.workflowstate', '-e', 'wagtailcore.comment',
+        '-e', 'auth.user', '-e', 'blowcomotion.sitesettings',
     ]
     
-    # For scrubbed dumps, also exclude auth users and site settings that contain passwords
-    args = list(base_args)
-    if not include_real_data:
-        args += ['-e', 'auth.user', '-e', 'blowcomotion.sitesettings']
+    args = base_args
     
     # Check if the user is superuser
     if not request.user.is_superuser:

--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -869,11 +869,15 @@ def dump_data(request):
                     item['fields']['live_revision'] = None
 
         # Clear user FKs that would otherwise reference excluded `auth.user` records
-        # (e.g. blowcomotion.CustomImage.uploaded_by_user)
+        # (e.g. wagtailimages.Image.uploaded_by_user, LibraryInstrument.locked_by, InstrumentHistoryLog.user)
+        user_fk_field_names = {'uploaded_by_user', 'user', 'locked_by', 'owner'}
         for item in data:
             fields = item.get('fields')
-            if fields and 'uploaded_by_user' in fields:
-                fields['uploaded_by_user'] = None
+            if not fields:
+                continue
+            for field_name in user_fk_field_names:
+                if field_name in fields:
+                    fields[field_name] = None
 
         # Scrub member data in-place if not including real data
         # This preserves Django's dependency ordering while scrubbing sensitive information


### PR DESCRIPTION
## Changes

This PR adds privacy-focused data scrubbing to the admin data dump endpoint, making it safe for local development while still allowing admins to export real data when needed.

**Resolves #192**

### Features Added

• **Data scrubbing by default**: Member data is scrubbed in-place while preserving PKs and relationships
• **Real data export option**: Add `?include_real_data=true` query parameter for actual member data
• **Preserves relationships**: Scrubbed members maintain PKs, instrument associations, and dates for testing
• **Always excludes credentials**: Auth users and site settings are excluded from all exports

### Scrubbed Fields

• Names → Generic `FirstName1`, `LastName2` format
• Emails → `member1@example.com` pattern
• Phone numbers → `555-0001` format
• Addresses → Generic Austin, TX addresses
• Personal messages → "Scrubbed for privacy" placeholder
• GigoGig identifiers → Nulled
• Member photos → Nulled

### Preserved Fields

• Primary instrument associations
• Birth dates (month, day, year)
• Join/separation/reactivation dates
• Boolean flags (is_active, instructor, board_member, renting)

### Usage

• **Default (scrubbed)**: `/admin/dump_data/` → Safe for sharing/local development
• **Real data**: `/admin/dump_data/?include_real_data=true` → Real member data only (credentials always excluded)

### Benefits

• Safe data exports for local development
• Preserves database structure and relationships for testing
• No sensitive member information exposed in default exports
• Cache-Control headers prevent accidental data retention
• Comprehensive test coverage (6 tests)