### PR TITLE
Add CSV export functionality for charts and corresponding tests

### DIFF
--- a/blowcomotion/management/commands/export_charts_to_csv.py
+++ b/blowcomotion/management/commands/export_charts_to_csv.py
@@ -1,0 +1,63 @@
+import csv
+import os
+from datetime import date, datetime
+
+from django.core.management.base import BaseCommand
+
+from blowcomotion.models import Chart
+
+
+class Command(BaseCommand):
+    help = "Export all charts and their fields to a CSV file."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--output",
+            dest="output_path",
+            default="charts_export.csv",
+            help="Destination path for the exported CSV (default: ./charts_export.csv)",
+        )
+
+    def handle(self, *args, **options):
+        output_path = options["output_path"]
+
+        directory = os.path.dirname(os.path.abspath(output_path)) or "."
+        os.makedirs(directory, exist_ok=True)
+
+        charts = Chart.objects.all().select_related('song', 'instrument', 'pdf').order_by('song__title', 'instrument__name', 'part')
+        if not charts.exists():
+            self.stdout.write(self.style.WARNING("No charts found to export."))
+
+        headers = [
+            "id",
+            "song_id",
+            "song_title",
+            "instrument_id",
+            "instrument_name",
+            "part",
+            "pdf_id",
+            "pdf_title",
+        ]
+
+        with open(output_path, "w", newline="", encoding="utf-8") as csvfile:
+            writer = csv.writer(csvfile)
+            writer.writerow(headers)
+
+            for chart in charts:
+                row = [
+                    chart.id,
+                    chart.song_id,
+                    chart.song.title if chart.song else "",
+                    chart.instrument_id,
+                    chart.instrument.name if chart.instrument else "",
+                    chart.part or "",
+                    chart.pdf_id,
+                    chart.pdf.title if chart.pdf else "",
+                ]
+                writer.writerow(row)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Export complete. {charts.count()} charts written to {output_path}"
+            )
+        )

--- a/blowcomotion/management/commands/export_charts_to_csv.py
+++ b/blowcomotion/management/commands/export_charts_to_csv.py
@@ -42,6 +42,7 @@ class Command(BaseCommand):
             writer = csv.writer(csvfile)
             writer.writerow(headers)
 
+            row_count = 0
             for chart in charts:
                 row = [
                     chart.id,
@@ -54,9 +55,10 @@ class Command(BaseCommand):
                     chart.pdf.title if chart.pdf else "",
                 ]
                 writer.writerow(row)
+                row_count += 1
 
         self.stdout.write(
             self.style.SUCCESS(
-                f"Export complete. {charts.count()} charts written to {output_path}"
+                f"Export complete. {row_count} charts written to {output_path}"
             )
         )

--- a/blowcomotion/management/commands/export_charts_to_csv.py
+++ b/blowcomotion/management/commands/export_charts_to_csv.py
@@ -1,6 +1,5 @@
 import csv
 import os
-from datetime import date, datetime
 
 from django.core.management.base import BaseCommand
 

--- a/blowcomotion/tests/test_export_charts_command.py
+++ b/blowcomotion/tests/test_export_charts_command.py
@@ -1,0 +1,171 @@
+"""
+Tests for the export_charts_to_csv management command.
+"""
+import csv
+import os
+import tempfile
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from blowcomotion.models import Chart
+
+
+class ExportChartsToCSVCommandTest(TestCase):
+    """Tests for the export_charts_to_csv management command."""
+
+    def test_export_charts_to_csv_with_existing_data(self):
+        """Test basic CSV export functionality with existing database data."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.csv') as tmp:
+            tmp_path = tmp.name
+
+        try:
+            out = StringIO()
+            call_command('export_charts_to_csv', output=tmp_path, stdout=out)
+
+            # Verify file was created
+            self.assertTrue(os.path.exists(tmp_path))
+
+            # Read and verify CSV content
+            with open(tmp_path, 'r', encoding='utf-8') as csvfile:
+                reader = csv.DictReader(csvfile)
+                rows = list(reader)
+
+            # Verify headers exist
+            if len(rows) > 0:
+                expected_headers = [
+                    'id',
+                    'song_id',
+                    'song_title',
+                    'instrument_id',
+                    'instrument_name',
+                    'part',
+                    'pdf_id',
+                    'pdf_title',
+                ]
+                self.assertEqual(list(rows[0].keys()), expected_headers)
+
+                # Verify data structure of first row
+                self.assertIn('id', rows[0])
+                self.assertIn('song_title', rows[0])
+                self.assertIn('instrument_name', rows[0])
+
+            # Verify command output
+            output = out.getvalue()
+            self.assertIn('written to', output)
+
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+
+    def test_export_charts_default_output_path(self):
+        """Test export with default output path."""
+        default_path = 'charts_export.csv'
+        
+        try:
+            out = StringIO()
+            call_command('export_charts_to_csv', stdout=out)
+
+            # Verify file was created at default location
+            self.assertTrue(os.path.exists(default_path))
+
+            # Verify command output
+            output = out.getvalue()
+            self.assertIn('Export complete', output)
+
+        finally:
+            if os.path.exists(default_path):
+                os.remove(default_path)
+
+    def test_export_charts_empty_database(self):
+        """Test export when no charts exist."""
+        # Get current chart count
+        initial_count = Chart.objects.count()
+        
+        # Delete all charts
+        Chart.objects.all().delete()
+
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.csv') as tmp:
+            tmp_path = tmp.name
+
+        try:
+            out = StringIO()
+            call_command('export_charts_to_csv', output=tmp_path, stdout=out)
+
+            # Verify file was created with just headers
+            with open(tmp_path, 'r', encoding='utf-8') as csvfile:
+                reader = csv.reader(csvfile)
+                rows = list(reader)
+
+            # Should have headers but no data rows
+            self.assertEqual(len(rows), 1)
+            
+            # Verify warning message
+            output = out.getvalue()
+            self.assertIn('No charts found', output)
+
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+
+    def test_export_charts_with_subdirectory(self):
+        """Test export to a path with subdirectories that don't exist yet."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, 'subdir', 'charts.csv')
+            
+            out = StringIO()
+            call_command('export_charts_to_csv', output=output_path, stdout=out)
+
+            # Verify file was created (directory should be created automatically)
+            self.assertTrue(os.path.exists(output_path))
+            
+            # Verify content has headers
+            with open(output_path, 'r', encoding='utf-8') as csvfile:
+                reader = csv.reader(csvfile)
+                headers = next(reader)
+            
+            # Verify we have the expected headers
+            expected_headers = [
+                'id',
+                'song_id',
+                'song_title',
+                'instrument_id',
+                'instrument_name',
+                'part',
+                'pdf_id',
+                'pdf_title',
+            ]
+            self.assertEqual(headers, expected_headers)
+
+    def test_export_charts_csv_format(self):
+        """Test that the CSV has proper format and required columns."""
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.csv') as tmp:
+            tmp_path = tmp.name
+
+        try:
+            call_command('export_charts_to_csv', output=tmp_path, stdout=StringIO())
+
+            with open(tmp_path, 'r', encoding='utf-8') as csvfile:
+                reader = csv.DictReader(csvfile)
+                headers = reader.fieldnames
+                
+                # Verify all required headers are present
+                required_headers = [
+                    'id',
+                    'song_id',
+                    'song_title',
+                    'instrument_id',
+                    'instrument_name',
+                    'part',
+                    'pdf_id',
+                    'pdf_title',
+                ]
+                
+                for header in required_headers:
+                    self.assertIn(header, headers)
+
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+

--- a/blowcomotion/tests/test_export_charts_command.py
+++ b/blowcomotion/tests/test_export_charts_command.py
@@ -9,7 +9,7 @@ from io import StringIO
 from django.core.management import call_command
 from django.test import TestCase
 
-from blowcomotion.models import Chart
+from blowcomotion.models import Chart, Instrument, Song
 
 
 class ExportChartsToCSVCommandTest(TestCase):
@@ -22,7 +22,7 @@ class ExportChartsToCSVCommandTest(TestCase):
 
         try:
             out = StringIO()
-            call_command('export_charts_to_csv', output=tmp_path, stdout=out)
+            call_command('export_charts_to_csv', output_path=tmp_path, stdout=out)
 
             # Verify file was created
             self.assertTrue(os.path.exists(tmp_path))
@@ -91,7 +91,7 @@ class ExportChartsToCSVCommandTest(TestCase):
 
         try:
             out = StringIO()
-            call_command('export_charts_to_csv', output=tmp_path, stdout=out)
+            call_command('export_charts_to_csv', output_path=tmp_path, stdout=out)
 
             # Verify file was created with just headers
             with open(tmp_path, 'r', encoding='utf-8') as csvfile:
@@ -115,7 +115,7 @@ class ExportChartsToCSVCommandTest(TestCase):
             output_path = os.path.join(tmpdir, 'subdir', 'charts.csv')
             
             out = StringIO()
-            call_command('export_charts_to_csv', output=output_path, stdout=out)
+            call_command('export_charts_to_csv', output_path=output_path, stdout=out)
 
             # Verify file was created (directory should be created automatically)
             self.assertTrue(os.path.exists(output_path))
@@ -144,7 +144,7 @@ class ExportChartsToCSVCommandTest(TestCase):
             tmp_path = tmp.name
 
         try:
-            call_command('export_charts_to_csv', output=tmp_path, stdout=StringIO())
+            call_command('export_charts_to_csv', output_path=tmp_path, stdout=StringIO())
 
             with open(tmp_path, 'r', encoding='utf-8') as csvfile:
                 reader = csv.DictReader(csvfile)

--- a/blowcomotion/tests/test_export_charts_command.py
+++ b/blowcomotion/tests/test_export_charts_command.py
@@ -80,9 +80,7 @@ class ExportChartsToCSVCommandTest(TestCase):
 
     def test_export_charts_empty_database(self):
         """Test export when no charts exist."""
-        # Get current chart count
-        initial_count = Chart.objects.count()
-        
+        # Ensure database is empty
         # Delete all charts
         Chart.objects.all().delete()
 

--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -1023,6 +1023,43 @@ def export_attendance_csv(request):
             logger.warning("Temporary file %s could not be removed after attendance export", temp_path)
 
 
+def export_charts_csv(request):
+    if not request.user.is_superuser:
+        logger.warning("Unauthorized access attempt to export charts by user %s", request.user.username)
+        return JsonResponse({'error': 'You must be a superuser to access this feature'}, status=403)
+
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix='.csv')
+    temp_path = temp_file.name
+    temp_file.close()
+
+    try:
+        logger.info("Starting chart export by user %s", request.user.username)
+        call_command(
+            'export_charts_to_csv',
+            output=temp_path,
+            stdout=StringIO(),
+        )
+
+    except Exception as e:
+        logger.error("Error during chart export by user %s: %s", request.user.username, str(e))
+        return JsonResponse({'error': str(e)}, status=500)
+    else:
+        with open(temp_path, 'rb') as csv_file:
+            csv_data = csv_file.read()
+
+        timestamp = timezone.now().strftime('%Y%m%d-%H%M%S')
+        filename = f'charts_export_{timestamp}.csv'
+        response = HttpResponse(csv_data, content_type='text/csv')
+        response['Content-Disposition'] = f'attachment; filename="{filename}"'
+        logger.info("Chart export completed successfully by user %s", request.user.username)
+        return response
+    finally:
+        try:
+            os.remove(temp_path)
+        except OSError:
+            logger.warning("Temporary file %s could not be removed after chart export", temp_path)
+
+
 def process_form(request):
     """
     Process the form submission.

--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -1036,7 +1036,7 @@ def export_charts_csv(request):
         logger.info("Starting chart export by user %s", request.user.username)
         call_command(
             'export_charts_to_csv',
-            output=temp_path,
+            output_path=temp_path,
             stdout=StringIO(),
         )
 

--- a/blowcomotion/wagtail_hooks.py
+++ b/blowcomotion/wagtail_hooks.py
@@ -78,7 +78,7 @@ def register_management_menu_item():
         MenuItem('Dump Data', reverse('dump_data'), icon_name='download'),
         MenuItem('Export Members CSV', reverse('export_members'), icon_name='table'),
         MenuItem('Export Attendance CSV', reverse('export_attendance'), icon_name='calendar'),
-        MenuItem('Export Charts CSV', reverse('export_charts'), icon_name='doc-full'),
+        MenuItem('Export Charts CSV', reverse('export_charts'), icon_name='doc-full-inverse'),
         MenuItem('Library: Rented', reverse('instrument_library_rented'), icon_name='french-horn'),
         MenuItem('Library: Available', reverse('instrument_library_available'), icon_name='french-horn'),
         MenuItem('Library: Maintenance', reverse('instrument_library_needs_repair'), icon_name='warning'),

--- a/blowcomotion/wagtail_hooks.py
+++ b/blowcomotion/wagtail_hooks.py
@@ -10,6 +10,7 @@ from django.utils.html import format_html
 from blowcomotion.views import (
     dump_data,
     export_attendance_csv,
+    export_charts_csv,
     export_members_csv,
     fetch_embed_data,
     instrument_library_available,
@@ -43,6 +44,7 @@ def register_admin_urls():
         path("dump_data/", dump_data, name="dump_data"),
         path("export_members/", export_members_csv, name="export_members"),
         path("export_attendance/", export_attendance_csv, name="export_attendance"),
+        path("export_charts/", export_charts_csv, name="export_charts"),
         path("embeds/fetch/", fetch_embed_data, name="fetch_embed_data"),
         path(
             "instrument-library/rented/",
@@ -76,6 +78,7 @@ def register_management_menu_item():
         MenuItem('Dump Data', reverse('dump_data'), icon_name='download'),
         MenuItem('Export Members CSV', reverse('export_members'), icon_name='table'),
         MenuItem('Export Attendance CSV', reverse('export_attendance'), icon_name='calendar'),
+        MenuItem('Export Charts CSV', reverse('export_charts'), icon_name='doc-full'),
         MenuItem('Library: Rented', reverse('instrument_library_rented'), icon_name='french-horn'),
         MenuItem('Library: Available', reverse('instrument_library_available'), icon_name='french-horn'),
         MenuItem('Library: Maintenance', reverse('instrument_library_needs_repair'), icon_name='warning'),


### PR DESCRIPTION
- Implemented management command to export charts to CSV.
- Added view to handle chart export requests, restricted to superusers.
- Created tests for the export command, covering various scenarios including existing data, default output path, and empty database.

resolves #203