### PR TITLE
feat: make chart library rows clickable to open PDF

### DIFF
--- a/blowcomotion/static/css/chart-library.css
+++ b/blowcomotion/static/css/chart-library.css
@@ -210,12 +210,17 @@
     background-color: #f5f5f5;
 }
 
-.accordion-song-header[role="button"]:focus-visible {
+.accordion-song-header[role="button"]:focus-visible,
+.accordion-song-header[role="link"]:focus-visible {
     outline: 3px solid rgba(91, 26, 118, 0.35);
     outline-offset: 2px;
 }
 
 .accordion-song[data-has-multiple="true"] .accordion-song-header {
+    cursor: pointer;
+}
+
+.accordion-song[data-pdf-url]:not([data-pdf-url=""]) .accordion-song-header[role="link"] {
     cursor: pointer;
 }
 
@@ -258,15 +263,44 @@
     justify-content: space-between;
     padding: 10px 16px;
     border-bottom: 1px solid #e5e5e5;
+    text-decoration: none;
+    color: inherit;
+    transition: background-color 0.15s ease;
 }
 
 .accordion-part:last-child {
     border-bottom: none;
 }
 
+a.accordion-part {
+    cursor: pointer;
+}
+
+a.accordion-part:hover {
+    background-color: #e5e5e5;
+    color: inherit;
+}
+
+a.accordion-part:focus-visible {
+    outline: 3px solid rgba(91, 26, 118, 0.35);
+    outline-offset: -2px;
+}
+
 .part-name {
     font-size: 13px;
     color: #555;
+}
+
+.part-pdf-icon {
+    color: #5b1a76;
+    font-size: 14px;
+    flex-shrink: 0;
+    opacity: 0.7;
+    transition: opacity 0.15s ease;
+}
+
+a.accordion-part:hover .part-pdf-icon {
+    opacity: 1;
 }
 
 /* ===== Media Icons ===== */
@@ -416,6 +450,20 @@
 
 .chart-pdf-btn i {
     font-size: 12px;
+}
+
+/* ===== Song PDF Indicator (single-chart row clickable affordance) ===== */
+.song-pdf-indicator {
+    color: #5b1a76;
+    font-size: 14px;
+    opacity: 0.6;
+    transition: opacity 0.15s ease;
+    display: flex;
+    align-items: center;
+}
+
+.accordion-song-header:hover .song-pdf-indicator {
+    opacity: 1;
 }
 
 /* ===== Inline Audio Player ===== */

--- a/blowcomotion/static/js/chart-library.js
+++ b/blowcomotion/static/js/chart-library.js
@@ -83,12 +83,14 @@
                     return;
                 }
 
-                // Song header toggle (for parts expansion)
+                // Song header toggle (for parts expansion) or PDF navigation (for single chart)
                 const songHeader = e.target.closest('.accordion-song-header');
-                if (songHeader && !e.target.closest('.song-play-btn') && !e.target.closest('.chart-pdf-btn') && !e.target.closest('.song-video-btn') && !e.target.closest('.video-dropdown')) {
+                if (songHeader && !e.target.closest('.song-play-btn') && !e.target.closest('.song-video-btn') && !e.target.closest('.video-dropdown')) {
                     const songItem = songHeader.closest('.accordion-song');
                     if (songItem.dataset.hasMultiple === 'true') {
                         this.toggleSongParts(songItem);
+                    } else if (songItem.dataset.pdfUrl) {
+                        window.open(songItem.dataset.pdfUrl, '_blank', 'noopener');
                     }
                     return;
                 }
@@ -141,6 +143,19 @@
                     if (songHeader) {
                         e.preventDefault();
                         this.toggleSongParts(songHeader.closest('.accordion-song'));
+                        return;
+                    }
+
+                }
+                // role="link" activates on Enter only (not Space per ARIA spec)
+                if (e.key === 'Enter') {
+                    const songLinkHeader = e.target.closest('.accordion-song-header[role="link"]');
+                    if (songLinkHeader) {
+                        e.preventDefault();
+                        const songItem = songLinkHeader.closest('.accordion-song');
+                        if (songItem.dataset.pdfUrl) {
+                            window.open(songItem.dataset.pdfUrl, '_blank', 'noopener');
+                        }
                         return;
                     }
                 }
@@ -307,10 +322,14 @@
             const html = songs.map(song => {
                 const hasMultipleCharts = song.charts && song.charts.length > 1;
                 const hasSingleChart = song.charts && song.charts.length === 1;
-                const pdfUrl = hasSingleChart ? song.charts[0].pdf_url : '';
+                const pdfUrl = hasSingleChart ? (song.charts[0].pdf_url || '') : '';
                 
+                const songHeaderRole = hasMultipleCharts
+                    ? ' role="button" tabindex="0" aria-expanded="false"'
+                    : (pdfUrl ? ` role="link" tabindex="0" aria-label="Open PDF for ${this.escapeHtml(song.title)}"` : '');
+
                 return `
-                <div class="accordion-song" 
+                <div class="accordion-song"
                      data-song-id="${song.id}"
                      data-song-title="${this.escapeHtml(song.title)}"
                      data-has-recording="${song.has_recording}"
@@ -318,9 +337,10 @@
                      data-has-video="${song.has_video}"
                      data-videos='${JSON.stringify(song.videos || []).replace(/'/g, "&#39;")}'
                      data-has-multiple="${hasMultipleCharts}"
+                     data-pdf-url="${this.escapeHtml(pdfUrl)}"
                      data-charts='${JSON.stringify(song.charts || []).replace(/'/g, "&#39;")}'
                      data-instrument-id="${instrumentId}">
-                    <div class="accordion-song-header"${hasMultipleCharts ? ' role="button" tabindex="0" aria-expanded="false"' : ''}>
+                    <div class="accordion-song-header"${songHeaderRole}>
                         <span class="song-media-icons">
                             <span class="media-icon-slot">
                                 ${song.has_recording ? `
@@ -336,12 +356,7 @@
                         <span class="accordion-song-title">${this.escapeHtml(song.title)}</span>
                         <span class="song-actions">
                             ${hasMultipleCharts ? '<i class="fa fa-chevron-right accordion-icon song-expand-icon"></i>' : ''}
-                            ${pdfUrl ? `
-                                <a href="${this.escapeHtml(pdfUrl)}" class="btn btn-sm btn-primary chart-pdf-btn" target="_blank" rel="noopener" title="Open Chart PDF">
-                                    <i class="fa fa-file-pdf-o"></i>
-                                    PDF
-                                </a>
-                            ` : ''}
+                            ${pdfUrl ? '<span class="song-pdf-indicator" aria-hidden="true"><i class="fa fa-file-pdf-o"></i></span>' : ''}
                         </span>
                     </div>
                     <div class="accordion-song-content">
@@ -411,17 +426,21 @@
                 try {
                     const charts = JSON.parse(songItem.dataset.charts || '[]');
                     if (charts.length > 0) {
-                        const partsHtml = charts.map(chart => `
-                            <div class="accordion-part" data-chart-id="${chart.id}">
-                                <span class="part-name">${this.escapeHtml(chart.part)}</span>
-                                ${chart.pdf_url ? `
-                                    <a href="${this.escapeHtml(chart.pdf_url)}" class="btn btn-sm btn-primary chart-pdf-btn" target="_blank" rel="noopener" title="Open Chart PDF">
-                                        <i class="fa fa-file-pdf-o"></i>
-                                        PDF
+                        const partsHtml = charts.map(chart => {
+                            if (chart.pdf_url) {
+                                return `
+                                    <a href="${this.escapeHtml(chart.pdf_url || '')}" class="accordion-part" data-chart-id="${chart.id}" target="_blank" rel="noopener" aria-label="Open PDF for ${this.escapeHtml(chart.part)}">
+                                        <span class="part-name">${this.escapeHtml(chart.part)}</span>
+                                        <span class="part-pdf-icon" aria-hidden="true"><i class="fa fa-file-pdf-o"></i></span>
                                     </a>
-                                ` : ''}
-                            </div>
-                        `).join('');
+                                `;
+                            }
+                            return `
+                                <div class="accordion-part" data-chart-id="${chart.id}">
+                                    <span class="part-name">${this.escapeHtml(chart.part)}</span>
+                                </div>
+                            `;
+                        }).join('');
                         content.innerHTML = `<div class="accordion-parts">${partsHtml}</div>`;
                     }
                 } catch (error) {


### PR DESCRIPTION
## Summary

- Single-chart song rows are now fully clickable — clicking anywhere on the row (excluding the play/video buttons) opens the PDF in a new tab
- Multi-chart song part rows are now rendered as `<a>` elements so the entire row is a native link to the PDF
- The explicit PDF button in single-chart rows is replaced by a subtle PDF icon indicator (non-interactive); the row itself is the navigation target
- Part rows with no PDF remain non-interactive `<div>` elements

## Details

**Single-chart song rows**
- Added `data-pdf-url` attribute to the song element
- Added `role="link"` + `tabindex="0"` + `aria-label` to the song header for keyboard and assistive-technology support
- Click handler navigates via `window.open(..., '_blank', 'noopener')` while still excluding play/video button clicks
- Enter key activates the link (Space does not — correct ARIA spec behaviour for `role="link"`)
- Cursor changes to pointer on hover; PDF icon brightens on hover as a visual affordance

**Multi-chart part rows**
- Each `accordion-part` with a `pdf_url` is now rendered as `<a href="..." target="_blank" rel="noopener">` covering the full row
- Replaces the old `btn btn-sm btn-primary chart-pdf-btn` button with a purple PDF icon on the right edge
- Hover background and focus ring applied to the whole row

**Defensive**
- `pdf_url` values are guarded with `|| ''` before `escapeHtml` to prevent `null`/`undefined` being stringified and passed to `window.open`

## Test plan

- [ ] Open a song with a single chart — click anywhere on the row (not the play/video icons) and confirm the PDF opens in a new tab
- [ ] Confirm the play and video buttons still work independently on single-chart rows
- [ ] Open a song with multiple charts — expand it and click a part row; confirm the PDF opens in a new tab
- [ ] Tab to a single-chart song row, press Enter — PDF should open; press Space — page should scroll (not open PDF)
- [ ] Tab to a part row (`<a>` element), press Enter — PDF should open
- [ ] Confirm a song/part with no PDF has no pointer cursor and no click action

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8aZba5oMYEzm29ydEnfJC)_