### PR TITLE
fix: member signup email quoted-printable encoding

### DIFF
--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -29,7 +29,11 @@ from blowcomotion.forms import (
     MemberSignupForm,
     SectionAttendanceForm,
 )
-from blowcomotion.member_auth import create_member_user, send_set_password_email
+from blowcomotion.member_auth import (
+    _MemberEmail,
+    create_member_user,
+    send_set_password_email,
+)
 from blowcomotion.models import (
     AttendanceRecord,
     BookingFormSubmission,
@@ -599,23 +603,15 @@ def _validate_recaptcha(request):
 
 def _send_form_email(subject, message, recipient_list):
     """Send email for form submission."""
-    send_mail(
-        subject=subject,
-        message=message,
-        from_email=settings.FROM_EMAIL,
-        recipient_list=recipient_list,
-        fail_silently=False,
-    )
+    _MemberEmail(
+        subject=subject, body=message, from_email=settings.FROM_EMAIL, to=recipient_list
+    ).send(fail_silently=False)
     # Send a copy for verifying functionality
     extra_email = settings.FORM_TEST_EMAIL if hasattr(settings, 'FORM_TEST_EMAIL') else None
     if extra_email:
-        send_mail(
-            subject=subject,
-            message=message,
-            from_email=settings.FROM_EMAIL,
-            recipient_list=[extra_email],
-            fail_silently=False,
-        )
+        _MemberEmail(
+            subject=subject, body=message, from_email=settings.FROM_EMAIL, to=[extra_email]
+        ).send(fail_silently=False)
 
 
 def _create_email_message(form_type, name, email, **kwargs):

--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -758,7 +758,7 @@ def _process_member_signup(request, form_data):
         if member.email:
             try:
                 create_member_user(member)
-                send_set_password_email(member, request)
+                send_set_password_email(member, f"{request.scheme}://{request.get_host()}")
                 logger.info(f"Sent set-password email to new member {member.pk}")
             except Exception as e:
                 logger.warning(f"Could not send set-password email to new member {member.pk}: {e}")


### PR DESCRIPTION
Closes #232

## Summary
- `_send_form_email` in `views.py` was using Django's `send_mail`, which uses `email.policy.default` with `max_line_length=78` — triggering quoted-printable soft-wrapping (`=` signs at line breaks) on any line over 78 chars
- The signup confirmation email has a 116-char line that reliably triggered this
- Fixed by swapping `send_mail` for `_MemberEmail`, the same class already used for set-password, email-change-confirmation, and signup-invite emails — it overrides the policy to `max_line_length=998`, keeping plain-text bodies as 7bit

## Test plan
- [ ] Submit a member signup form and confirm the confirmation email arrives without `=` signs
- [ ] Confirm the admin notification email also arrives cleanly
- [ ] Run existing email tests: `python manage.py test blowcomotion.tests.test_member_auth_views`