### PR TITLE
refactor: remove honeypot pattern, verify all public forms use reCAPTCHA

### DIFF
--- a/blowcomotion/member_views.py
+++ b/blowcomotion/member_views.py
@@ -29,7 +29,7 @@ from blowcomotion.models import (
     MemberInstrument,
     PasswordSetToken,
 )
-from blowcomotion.views import _validate_honeypot, _validate_recaptcha
+from blowcomotion.views import _validate_recaptcha
 
 logger = logging.getLogger(__name__)
 User = get_user_model()
@@ -43,8 +43,6 @@ class MemberLoginView(auth_views.LoginView):
     template_name = "member/login.html"
 
     def post(self, request, *args, **kwargs):
-        if not _validate_honeypot(request):
-            return redirect("/")
         is_valid, error = _validate_recaptcha(request)
         if not is_valid:
             form = self.get_form_class()()
@@ -73,8 +71,6 @@ def set_password_view(request, token_uuid):
         return render(request, "member/set_password.html", {"expired": True})
 
     if request.method == "POST":
-        if not _validate_honeypot(request):
-            return redirect("/")
         is_valid, error = _validate_recaptcha(request)
         if not is_valid:
             form = SetPasswordForm(user=token.member.user)
@@ -116,8 +112,6 @@ class MemberPasswordResetView(auth_views.PasswordResetView):
     email_template_name = "member/password_reset_email.txt"
 
     def post(self, request, *args, **kwargs):
-        if not _validate_honeypot(request):
-            return redirect("/")
         is_valid, error = _validate_recaptcha(request)
         if not is_valid:
             form = self.get_form_class()()
@@ -153,8 +147,6 @@ class MemberPasswordResetView(auth_views.PasswordResetView):
 @ratelimit(key="ip", rate="10/h", method="POST", block=True)
 def get_access_view(request):
     if request.method == "POST":
-        if not _validate_honeypot(request):
-            return redirect("/")
         is_valid, error = _validate_recaptcha(request)
         if not is_valid:
             form = GetAccessForm(request.POST)

--- a/blowcomotion/static/js/form.js
+++ b/blowcomotion/static/js/form.js
@@ -1,8 +1,5 @@
 (function ($) {
     $(document).ready(function() {
-        // Set honeypot field value (spam protection)
-        $('.best-color').val("purple");
-        
         // reCAPTCHA v3 form handling
         // For HTMX forms, we need to get the token and add it to the request
         if (typeof grecaptcha !== 'undefined' && window.RECAPTCHA_SITE_KEY) {

--- a/blowcomotion/templates/blocks/booking_form_block.html
+++ b/blowcomotion/templates/blocks/booking_form_block.html
@@ -8,7 +8,6 @@
             <form hx-post="{% url 'process-form' %}" name="booking-form" hx-indicator="#booking-form-spinner">
                 <div class="input__list row">
                     {% csrf_token %}
-                    <input type="text" class="best-color" name="best_color" value="" style="display:none;">
                     <div class="form-group col-sm-6">
                         <label for="name">{{ value.name_field_label|default:"Your Name:" }} <span class="text-danger">*</span></label>
                         <input type="text" class="form-control" id="name" name="name" placeholder="Your Name" required>

--- a/blowcomotion/templates/blocks/contact_form_block.html
+++ b/blowcomotion/templates/blocks/contact_form_block.html
@@ -7,7 +7,6 @@
             <form hx-post="{% url 'process-form' %}" name="contact-form">
                 <div class="input__list row">
                     {% csrf_token %}
-                    <input type="text" class="best-color" name="best_color" value="" style="display:none;">
                     <div class="form-group col-sm-6">
                         <input type="text" class="form-control" id="name" name="name" placeholder="Your Name" required>
                     </div>

--- a/blowcomotion/templates/blocks/donate_form_block.html
+++ b/blowcomotion/templates/blocks/donate_form_block.html
@@ -7,7 +7,6 @@
             <form hx-post="{% url 'process-form' %}" name="donate-form">
                 <div class="input__list row">
                     {% csrf_token %}
-                    <input type="text" class="best-color" name="best_color" value="" style="display:none;">
                     <div class="form-group col-sm-6">
                         <label for="name">{{ value.name_field_label|default:"Your Name:" }}</label>
                         <input type="text" class="form-control" id="name" name="name" placeholder="Your Name" required>

--- a/blowcomotion/templates/blocks/join_band_form_block.html
+++ b/blowcomotion/templates/blocks/join_band_form_block.html
@@ -7,7 +7,6 @@
             <form hx-post="{% url 'process-form' %}" name="join-band-form">
                 <div class="input__list row">
                     {% csrf_token %}
-                    <input type="text" class="best-color" name="best_color" value="" style="display:none;">
                     <div class="form-group col-sm-6">
                         <input type="text" class="form-control" id="name" name="name" placeholder="Your Name" required>
                     </div>

--- a/blowcomotion/templates/blocks/member_signup_form_block.html
+++ b/blowcomotion/templates/blocks/member_signup_form_block.html
@@ -28,7 +28,6 @@
                 <div class="card-body p-4">
                     <form hx-post="{% url 'process-form' %}" name="member-signup-form">
                         {% csrf_token %}
-                        <input type="text" class="best-color" name="best_color" value="" style="display:none;">
                         <input type="hidden" name="form_type" value="member_signup_form">
 
                         <!-- Personal Information Section -->

--- a/blowcomotion/templates/forms/feedback_form_modal.html
+++ b/blowcomotion/templates/forms/feedback_form_modal.html
@@ -13,7 +13,6 @@
                 <form hx-post="{% url 'process-form' %}" name="feedback-form">
                     <div class="input__list row">
                         {% csrf_token %}
-                        <input type="text" class="best-color" name="best_color" value="" style="display:none;">
                         <input type="text" name="page_url" value="{{ request.path }}" style="display:none;">
                         <div class="form-group col-sm-6">
                             <input type="text" class="form-control" id="name" name="name" placeholder="Your Name" required>

--- a/blowcomotion/templates/member/get_access.html
+++ b/blowcomotion/templates/member/get_access.html
@@ -13,7 +13,6 @@
                 <p class="text-muted mb-4">Enter your member email address and we'll send you a link to set up your account.</p>
                 <form method="post" id="member-form">
                     {% csrf_token %}
-                    <input type="text" name="best_color" class="best-color" style="display:none;" tabindex="-1" autocomplete="off">
                     <input type="hidden" name="g-recaptcha-response" value="">
                     <div class="mb-3">
                         <label for="{{ form.email.id_for_label }}" class="form-label">{{ form.email.label }}</label>

--- a/blowcomotion/templates/member/login.html
+++ b/blowcomotion/templates/member/login.html
@@ -9,7 +9,6 @@
             {% if recaptcha_error %}<div class="alert alert-danger">{{ recaptcha_error }}</div>{% endif %}
             <form method="post" id="member-form">
                 {% csrf_token %}
-                <input type="text" name="best_color" class="best-color" style="display:none;" tabindex="-1" autocomplete="off">
                 <input type="hidden" name="g-recaptcha-response" value="">
                 <div class="mb-3">
                     <label for="id_username" class="form-label">Email address</label>

--- a/blowcomotion/templates/member/password_reset.html
+++ b/blowcomotion/templates/member/password_reset.html
@@ -9,7 +9,6 @@
             {% if recaptcha_error %}<div class="alert alert-danger">{{ recaptcha_error }}</div>{% endif %}
             <form method="post" id="member-form">
                 {% csrf_token %}
-                <input type="text" name="best_color" class="best-color" style="display:none;" tabindex="-1" autocomplete="off">
                 <input type="hidden" name="g-recaptcha-response" value="">
                 <div class="mb-3">
                     <label for="id_email" class="form-label">Email address</label>

--- a/blowcomotion/templates/member/set_password.html
+++ b/blowcomotion/templates/member/set_password.html
@@ -13,7 +13,6 @@
                 {% if recaptcha_error %}<div class="alert alert-danger">{{ recaptcha_error }}</div>{% endif %}
                 <form method="post" id="member-form">
                     {% csrf_token %}
-                    <input type="text" name="best_color" class="best-color" style="display:none;" tabindex="-1" autocomplete="off">
                     <input type="hidden" name="g-recaptcha-response" value="">
                     <div class="mb-3">
                         <label for="id_new_password1" class="form-label">New password</label>

--- a/blowcomotion/tests/test_member_auth_views.py
+++ b/blowcomotion/tests/test_member_auth_views.py
@@ -38,16 +38,10 @@ class LoginViewTests(TestCase):
     def test_valid_login_redirects_to_profile(self, mock_recaptcha):
         response = self.client.post(
             reverse("member-login"),
-            {"username": "sam@example.com", "password": "Str0ngP@ss!", "best_color": "purple"},
+            {"username": "sam@example.com", "password": "Str0ngP@ss!"},
         )
         self.assertRedirects(response, "/member/profile/", fetch_redirect_response=False)
 
-    def test_honeypot_filled_redirects_silently(self):
-        response = self.client.post(
-            reverse("member-login"),
-            {"username": "sam@example.com", "password": "x", "best_color": "red"},
-        )
-        self.assertEqual(response.status_code, 302)
 
     def test_recaptcha_fail_stays_on_login(self):
         with patch(
@@ -56,7 +50,7 @@ class LoginViewTests(TestCase):
         ):
             response = self.client.post(
                 reverse("member-login"),
-                {"username": "sam@example.com", "password": "Str0ngP@ss!", "best_color": "purple"},
+                {"username": "sam@example.com", "password": "Str0ngP@ss!"},
             )
         self.assertEqual(response.status_code, 200)
 
@@ -113,7 +107,7 @@ class SetPasswordViewTests(TestCase):
         token = self._make_token()
         response = self.client.post(
             reverse("member-set-password", kwargs={"token_uuid": token.uuid}),
-            {"new_password1": "NewStr0ng@Pass!", "new_password2": "NewStr0ng@Pass!", "best_color": "purple"},
+            {"new_password1": "NewStr0ng@Pass!", "new_password2": "NewStr0ng@Pass!"},
         )
         self.assertRedirects(response, "/member/profile/", fetch_redirect_response=False)
         token.refresh_from_db()
@@ -130,7 +124,7 @@ class GetAccessViewTests(TestCase):
     @recaptcha_pass
     def test_unknown_email_receives_signup_invite(self, mock_recaptcha):
         response = self.client.post(
-            reverse("member-get-access"), {"email": "nobody@example.com", "best_color": "purple"}
+            reverse("member-get-access"), {"email": "nobody@example.com"}
         )
         self.assertEqual(response.status_code, 200)
         from django.core import mail
@@ -141,7 +135,7 @@ class GetAccessViewTests(TestCase):
     def test_member_without_user_creates_account_and_sends_email(self, mock_recaptcha):
         make_member(email="newbie@example.com")
         response = self.client.post(
-            reverse("member-get-access"), {"email": "newbie@example.com", "best_color": "purple"}
+            reverse("member-get-access"), {"email": "newbie@example.com"}
         )
         self.assertEqual(response.status_code, 200)
         from django.core import mail
@@ -156,7 +150,7 @@ class GetAccessViewTests(TestCase):
         user.set_password("SomePass123!")
         user.save()
         response = self.client.post(
-            reverse("member-get-access"), {"email": "existing@example.com", "best_color": "purple"}
+            reverse("member-get-access"), {"email": "existing@example.com"}
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(mail.outbox), 1)
@@ -166,7 +160,7 @@ class GetAccessViewTests(TestCase):
         from django.core import mail
         make_member(email="inactive@example.com", is_active=False)
         response = self.client.post(
-            reverse("member-get-access"), {"email": "inactive@example.com", "best_color": "purple"}
+            reverse("member-get-access"), {"email": "inactive@example.com"}
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(mail.outbox), 1)
@@ -181,7 +175,7 @@ class GetAccessViewTests(TestCase):
         user.set_password("OldPass123!")
         user.save()
         response = self.client.post(
-            reverse("member-get-access"), {"email": "oldmember@example.com", "best_color": "purple"}
+            reverse("member-get-access"), {"email": "oldmember@example.com"}
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(mail.outbox), 1)
@@ -193,7 +187,7 @@ class GetAccessViewTests(TestCase):
         make_member(email="dupe@example.com")
         make_member(first_name="Other", last_name="Also", email="dupe@example.com")
         response = self.client.post(
-            reverse("member-get-access"), {"email": "dupe@example.com", "best_color": "purple"}
+            reverse("member-get-access"), {"email": "dupe@example.com"}
         )
         self.assertEqual(response.status_code, 200)
 
@@ -201,7 +195,7 @@ class GetAccessViewTests(TestCase):
     def test_signup_invite_email_not_qp_wrapped(self, mock_recaptcha):
         from django.core import mail
         self.client.post(
-            reverse("member-get-access"), {"email": "newperson2@example.com", "best_color": "purple"}
+            reverse("member-get-access"), {"email": "newperson2@example.com"}
         )
         raw = mail.outbox[0].message().as_string()
         self.assertNotIn("=\n", raw)
@@ -212,7 +206,7 @@ class GetAccessViewTests(TestCase):
         from django.core import mail
         for _ in range(3):
             self.client.post(
-                reverse("member-get-access"), {"email": "newperson@example.com", "best_color": "purple"}
+                reverse("member-get-access"), {"email": "newperson@example.com"}
             )
         self.assertEqual(len(mail.outbox), 2)
 
@@ -227,7 +221,7 @@ class SetPasswordReactivationTests(TestCase):
             token = PasswordSetToken.objects.create(member=member)
             response = self.client.post(
                 reverse("member-set-password", kwargs={"token_uuid": token.uuid}),
-                {"new_password1": "FreshP@ss1!", "new_password2": "FreshP@ss1!", "best_color": "purple"},
+                {"new_password1": "FreshP@ss1!", "new_password2": "FreshP@ss1!"},
             )
             self.assertRedirects(response, "/member/profile/", fetch_redirect_response=False)
             member.refresh_from_db()
@@ -240,7 +234,7 @@ class SetPasswordReactivationTests(TestCase):
             token = PasswordSetToken.objects.create(member=member)
             response = self.client.post(
                 reverse("member-set-password", kwargs={"token_uuid": token.uuid}),
-                {"new_password1": "FreshP@ss1!", "new_password2": "FreshP@ss1!", "best_color": "purple"},
+                {"new_password1": "FreshP@ss1!", "new_password2": "FreshP@ss1!"},
             )
             self.assertRedirects(response, "/member/profile/", fetch_redirect_response=False)
             member.refresh_from_db()
@@ -257,7 +251,7 @@ class PasswordResetViewTests(TestCase):
         make_member(first_name="Other3", last_name="Also", email="dupe3@example.com")
         response = self.client.post(
             reverse("member-password-reset"),
-            {"email": "dupe3@example.com", "best_color": "purple"},
+            {"email": "dupe3@example.com"},
         )
         self.assertIn(response.status_code, [200, 302])
 
@@ -271,7 +265,7 @@ class PasswordResetViewTests(TestCase):
         user.save()
         self.client.post(
             reverse("member-password-reset"),
-            {"email": "haspass@example.com", "best_color": "purple"},
+            {"email": "haspass@example.com"},
         )
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].from_email, "noreply@blowcomotion.org")

--- a/blowcomotion/tests/test_member_signup_go3.py
+++ b/blowcomotion/tests/test_member_signup_go3.py
@@ -483,7 +483,7 @@ class MemberSignupCreatesUserTests(TestCase):
             "/process-form/",
             {
                 "form_type": "member_signup_form",
-                    "first_name": "Alex",
+                "first_name": "Alex",
                 "last_name": "Musician",
                 "email": "alex@example.com",
                 "primary_instrument": self.instrument.pk,

--- a/blowcomotion/tests/test_member_signup_go3.py
+++ b/blowcomotion/tests/test_member_signup_go3.py
@@ -264,7 +264,6 @@ class MemberSignupGO3IntegrationTests(TestCase):
         
         form_data = {
             'form_type': 'member_signup_form',
-            'best_color': 'purple',
             'first_name': 'John',
             'last_name': 'Doe',
             'email': 'john@example.com',
@@ -290,7 +289,6 @@ class MemberSignupGO3IntegrationTests(TestCase):
         """Test that signup requires primary_instrument field"""
         form_data = {
             'form_type': 'member_signup_form',
-            'best_color': 'purple',
             'first_name': 'Jane',
             'last_name': 'Doe',
             'email': 'jane@example.com',
@@ -312,7 +310,6 @@ class MemberSignupGO3IntegrationTests(TestCase):
         """Test that signup requires email field (needed for GO3 invite)"""
         form_data = {
             'form_type': 'member_signup_form',
-            'best_color': 'purple',
             'first_name': 'Jane',
             'last_name': 'Doe',
             'primary_instrument': self.instrument.pk
@@ -346,7 +343,6 @@ class MemberSignupGO3IntegrationTests(TestCase):
         
         form_data = {
             'form_type': 'member_signup_form',
-            'best_color': 'purple',
             'first_name': 'Bob',
             'last_name': 'Smith',
             'email': 'bob@example.com',
@@ -395,7 +391,6 @@ class MemberSignupGO3IntegrationTests(TestCase):
         
         form_data = {
             'form_type': 'member_signup_form',
-            'best_color': 'purple',
             'first_name': 'Alice',
             'last_name': 'Johnson',
             'email': 'alice@example.com',
@@ -430,7 +425,6 @@ class MemberSignupGO3IntegrationTests(TestCase):
         
         form_data = {
             'form_type': 'member_signup_form',
-            'best_color': 'purple',
             'first_name': 'Charlie',
             'last_name': 'Brown',
             'email': 'charlie@example.com',
@@ -489,8 +483,7 @@ class MemberSignupCreatesUserTests(TestCase):
             "/process-form/",
             {
                 "form_type": "member_signup_form",
-                "best_color": "purple",
-                "first_name": "Alex",
+                    "first_name": "Alex",
                 "last_name": "Musician",
                 "email": "alex@example.com",
                 "primary_instrument": self.instrument.pk,

--- a/blowcomotion/tests/test_recaptcha.py
+++ b/blowcomotion/tests/test_recaptcha.py
@@ -225,7 +225,6 @@ class ProcessFormRecaptchaIntegrationTests(TestCase):
             'form_type': 'feedback_form',
             'name': 'Test User',
             'message': 'Test message',
-            'best_color': 'purple',  # Honeypot
         })
         
         # Should succeed (render success template)
@@ -240,7 +239,6 @@ class ProcessFormRecaptchaIntegrationTests(TestCase):
             'form_type': 'feedback_form',
             'name': 'Test User',
             'message': 'Test message',
-            'best_color': 'purple',
         })
         
         self.assertEqual(response.status_code, 200)
@@ -253,7 +251,6 @@ class ProcessFormRecaptchaIntegrationTests(TestCase):
             'form_type': 'feedback_form',
             'name': 'Test User',
             'message': 'Test message',
-            'best_color': 'purple',
             # No g-recaptcha-response
         })
         
@@ -277,7 +274,6 @@ class ProcessFormRecaptchaIntegrationTests(TestCase):
             'form_type': 'feedback_form',
             'name': 'Test User',
             'message': 'Test message',
-            'best_color': 'purple',
             'g-recaptcha-response': 'test-token',
         })
         
@@ -301,7 +297,6 @@ class ProcessFormRecaptchaIntegrationTests(TestCase):
             'form_type': 'feedback_form',
             'name': 'Test User',
             'message': 'Test message',
-            'best_color': 'purple',
             'g-recaptcha-response': 'test-token',
         })
         

--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -518,12 +518,6 @@ def _get_form_recipients(site_settings, form_type):
     return recipient_mapping.get(form_type)
 
 
-def _validate_honeypot(request):
-    """Validate honeypot field."""
-    honeypot = request.POST.get('best_color')
-    return honeypot == 'purple'
-
-
 def _validate_recaptcha(request):
     """
     Validate reCAPTCHA v3 token from the request.
@@ -1244,15 +1238,8 @@ def process_form(request):
     Process the form submission.
     """
     context = {}
-    honeypot_message = 'Honeypot triggered. Form submission failed. Is your javascript enabled?'
-    
+
     if request.method == 'POST':
-        # Validate honeypot field
-        if not _validate_honeypot(request):
-            logger.warning(f"Honeypot triggered by user {request.user.username}")
-            context['error'] = honeypot_message
-            return render(request, 'forms/error.html', context)
-        
         # Validate reCAPTCHA
         recaptcha_valid, recaptcha_error = _validate_recaptcha(request)
         if not recaptcha_valid:
@@ -1369,10 +1356,6 @@ def process_form(request):
         else:
             # Handle unknown form types
             logger.info(f"Processing unknown form type submission by user {request.user.username}")
-            if not _validate_honeypot(request):
-                logger.warning(f"Honeypot triggered by user {request.user.username}")
-                context['error'] = honeypot_message
-                return render(request, 'forms/error.html', context)
             context['message'] = 'Form submitted successfully!'
     
     else:


### PR DESCRIPTION
Closes #223

## Summary

- Deletes `_validate_honeypot()` from `views.py` and removes all 6 call sites across `views.py` and `member_views.py`
- Removes `best_color` hidden inputs from 10 templates
- Removes the single JS line in `form.js` that set the honeypot field value
- All 10 affected forms had active `_validate_recaptcha()` before and continue to after — verified by audit

## Test plan

- [x] 56 tests pass (`test_recaptcha`, `test_member_auth_views`, `test_member_signup_go3`)
- [x] `test_honeypot_filled_redirects_silently` deleted (behaviour no longer exists)
- [x] `best_color` removed from all test POST dicts
- [x] No `best_color`, `honeypot`, or `_validate_honeypot` references remain in source