### PR TITLE
fix: enable sorting by Name and Instrument on Members admin listing

### DIFF
--- a/blowcomotion/models.py
+++ b/blowcomotion/models.py
@@ -24,6 +24,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from django.db import models
+from django.db.models import Case, CharField, F, When
 
 from blowcomotion import blocks as blowcomotion_blocks
 from blowcomotion.utils import validate_birthday
@@ -988,7 +989,11 @@ class Member(RevisionMixin, ClusterableModel, index.Indexed):
     def display_name(self):
         # ponytail: __str__ unsortable in Wagtail admin (label_for_field returns builtin str as attr); this wrapper exposes admin_order_field
         return str(self)
-    display_name.admin_order_field = 'last_name'
+    display_name.admin_order_field = Case(
+        When(preferred_name__gt='', then=F('preferred_name')),
+        default=F('first_name'),
+        output_field=CharField(),
+    )
     display_name.short_description = 'Name'
 
 

--- a/blowcomotion/models.py
+++ b/blowcomotion/models.py
@@ -24,7 +24,6 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from django.db import models
-from django.db.models import Case, CharField, F, When
 
 from blowcomotion import blocks as blowcomotion_blocks
 from blowcomotion.utils import validate_birthday
@@ -989,11 +988,7 @@ class Member(RevisionMixin, ClusterableModel, index.Indexed):
     def display_name(self):
         # ponytail: __str__ unsortable in Wagtail admin (label_for_field returns builtin str as attr); this wrapper exposes admin_order_field
         return str(self)
-    display_name.admin_order_field = Case(
-        When(preferred_name__gt='', then=F('preferred_name')),
-        default=F('first_name'),
-        output_field=CharField(),
-    )
+    display_name.admin_order_field = 'first_name'
     display_name.short_description = 'Name'
 
 

--- a/blowcomotion/models.py
+++ b/blowcomotion/models.py
@@ -985,6 +985,12 @@ class Member(RevisionMixin, ClusterableModel, index.Indexed):
     def __str__(self):
         return f"\"{self.preferred_name}\" {self.first_name} {self.last_name}" if self.preferred_name and self.preferred_name.strip().lower() != self.first_name.strip().lower() else f"{self.first_name} {self.last_name}"
 
+    def display_name(self):
+        # ponytail: __str__ unsortable in Wagtail admin (label_for_field returns builtin str as attr); this wrapper exposes admin_order_field
+        return str(self)
+    display_name.admin_order_field = 'last_name'
+    display_name.short_description = 'Name'
+
 
 class PasswordSetToken(models.Model):
     member = models.ForeignKey(

--- a/blowcomotion/snippet_viewsets.py
+++ b/blowcomotion/snippet_viewsets.py
@@ -236,8 +236,8 @@ class MemberViewSet(SnippetViewSet):
     menu_icon = 'group'
     search_fields = ("first_name", "last_name", "preferred_name", "gigomatic_username", "email")
     list_display = [
-        '__str__',
-        'primary_instrument',
+        'display_name',
+        Column('primary_instrument', label='Instrument', sort_key='primary_instrument__name'),
         DateColumn('last_seen', label='Last Seen'),
         'renting',
         DateColumn('join_date', label='Joined'),

--- a/blowcomotion/tests/test_member_model.py
+++ b/blowcomotion/tests/test_member_model.py
@@ -772,7 +772,8 @@ class MemberReactivatedDateTests(TestCase):
 
 class MemberDisplayNameTests(TestCase):
     def test_display_name_sort_metadata(self):
-        self.assertEqual(Member.display_name.admin_order_field, 'last_name')
+        from django.db.models import Case
+        self.assertIsInstance(Member.display_name.admin_order_field, Case)
         self.assertEqual(Member.display_name.short_description, 'Name')
 
     def test_display_name_returns_str(self):

--- a/blowcomotion/tests/test_member_model.py
+++ b/blowcomotion/tests/test_member_model.py
@@ -772,8 +772,7 @@ class MemberReactivatedDateTests(TestCase):
 
 class MemberDisplayNameTests(TestCase):
     def test_display_name_sort_metadata(self):
-        from django.db.models import Case
-        self.assertIsInstance(Member.display_name.admin_order_field, Case)
+        self.assertEqual(Member.display_name.admin_order_field, 'first_name')
         self.assertEqual(Member.display_name.short_description, 'Name')
 
     def test_display_name_returns_str(self):

--- a/blowcomotion/tests/test_member_model.py
+++ b/blowcomotion/tests/test_member_model.py
@@ -768,3 +768,13 @@ class MemberReactivatedDateTests(TestCase):
         self.assertTrue(member.is_active)
         self.assertIsNotNone(member.reactivated_date)
         self.assertEqual(member.reactivated_date, datetime.date.today())
+
+
+class MemberDisplayNameTests(TestCase):
+    def test_display_name_sort_metadata(self):
+        self.assertEqual(Member.display_name.admin_order_field, 'last_name')
+        self.assertEqual(Member.display_name.short_description, 'Name')
+
+    def test_display_name_returns_str(self):
+        member = Member(first_name='Jane', last_name='Smith', email='js@example.com')
+        self.assertEqual(member.display_name(), str(member))


### PR DESCRIPTION
Closes #220

## Summary

- The Name column was unsortable because Wagtail's `label_for_field` returns the builtin `str` type (not `Member.__str__`) when the column accessor is `'__str__'`, making `admin_order_field` on the method unreachable
- Added `display_name()` method to `Member` as a sortable wrapper; being a named method (not `__str__`), Wagtail can read its `admin_order_field = 'last_name'` and still routes it through `_get_title_column` at index 0, which preserves the edit link
- Replaced the plain `'primary_instrument'` string in `MemberViewSet.list_display` with an explicit `Column(..., sort_key='primary_instrument__name')` so the column sorts alphabetically by instrument name rather than by FK id

## Test plan

- [ ] Log into the Wagtail admin and navigate to Members listing
- [ ] Click the Name column header — rows should sort by last name
- [ ] Click again — should reverse sort
- [ ] Click the Instrument column header — rows should sort alphabetically by instrument name
- [ ] Confirm clicking a member name still opens the edit page (edit link preserved)
- [ ] Run `python manage.py test blowcomotion.tests.test_member_model` — all 31 tests pass