### PR TITLE
Fix member admin search crashing on SQLite

### DIFF
--- a/blowcomotion/member_auth.py
+++ b/blowcomotion/member_auth.py
@@ -115,6 +115,20 @@ def send_email_change_confirmation(member, new_email, base_url):
     logger.info(f"Sent email-change confirmation to {new_email} for member {member.pk}")
 
 
+def send_member_signup_welcome_email(member, base_url):
+    """Create a PasswordSetToken and email the new member a welcome with both next steps."""
+    _supersede_set_password_tokens(member)
+    token = PasswordSetToken.objects.create(member=member)
+    set_password_url = f"{base_url}/member/set-password/{token.uuid}/"
+    subject = "Welcome to Blowcomotion - Next Steps"
+    message = render_to_string(
+        "emails/member_signup_welcome.txt",
+        {"member": member, "set_password_url": set_password_url},
+    )
+    _send_mail(subject, message, settings.FROM_EMAIL, member.email)
+    logger.info(f"Sent signup welcome email to member {member.pk} ({member.email})")
+
+
 def send_signup_invite_email(email, base_url):
     """Send a signup link to an address not found in the member list.
 

--- a/blowcomotion/models.py
+++ b/blowcomotion/models.py
@@ -649,26 +649,16 @@ class Member(RevisionMixin, ClusterableModel, index.Indexed):
     notify_reminders = models.BooleanField(default=True)
     notify_announcements = models.BooleanField(default=True)
 
-    # Commenting out search_fields to avoid FTS indexing issues
-    # Admin search still works via snippet_viewsets.py search_fields
     search_fields = [
         index.SearchField("first_name"),
         index.SearchField("last_name"),
         index.SearchField("preferred_name"),
         index.SearchField("gigomatic_username"),
+        index.SearchField("email"),
         index.AutocompleteField("first_name"),
         index.AutocompleteField("last_name"),
         index.AutocompleteField("preferred_name"),
         index.AutocompleteField("gigomatic_username"),
-        index.SearchField("bio"),
-        index.SearchField("email"),
-        index.SearchField("phone"),
-        index.SearchField("address"),
-        index.SearchField("city"),
-        index.SearchField("state"),
-        index.SearchField("zip_code"),
-        index.SearchField("country"),
-        index.SearchField("notes"),
     ]
 
     def clean(self):

--- a/blowcomotion/snippet_viewsets.py
+++ b/blowcomotion/snippet_viewsets.py
@@ -234,7 +234,7 @@ class MemberViewSet(SnippetViewSet):
     menu_label = 'Members'
     menu_name = 'members'
     menu_icon = 'group'
-    search_fields = ("first_name", "last_name", "preferred_name", "gigomatic_username", "email")
+    search_fields = None  # Use model's index.SearchField definitions; string names break SQLite FTS
     list_display = [
         'display_name',
         Column('primary_instrument', label='Instrument', sort_key='primary_instrument__name'),

--- a/blowcomotion/templates/emails/member_signup_welcome.txt
+++ b/blowcomotion/templates/emails/member_signup_welcome.txt
@@ -1,0 +1,16 @@
+Hi {{ member.preferred_name|default:member.first_name }},
+
+Thank you for signing up with Blowcomotion! You've been added to our band.
+
+Here are your next steps:
+
+1. Set your password on the Blowcomotion website:
+
+   {{ set_password_url }}
+
+   This link expires in 24 hours and can only be used once.
+
+2. Look for an email from "superuser@gig-o-matic.com" and complete the registration process there.
+
+Start Wearing Purple,
+Blowcomotion

--- a/blowcomotion/tests/test_member_signup_go3.py
+++ b/blowcomotion/tests/test_member_signup_go3.py
@@ -434,16 +434,10 @@ class MemberSignupGO3IntegrationTests(TestCase):
         
         response = self.client.post(reverse('process-form'), form_data)
         
-        # Verify emails were sent
-        self.assertEqual(mock_email.call_count, 2)  # One to admin, one to member
-        
-        # Verify first call was admin notification
+        # Only admin notification goes via _send_form_email; member welcome uses _MemberEmail
+        self.assertEqual(mock_email.call_count, 1)
         first_call_args = mock_email.call_args_list[0]
         self.assertEqual(first_call_args[1]['subject'], 'New Member Signup')
-        
-        # Verify second call was member confirmation
-        second_call_args = mock_email.call_args_list[1]
-        self.assertEqual(second_call_args[1]['subject'], 'Welcome to Blowcomotion - Application Received')
 
 
 class MemberSignupCreatesUserTests(TestCase):
@@ -489,11 +483,14 @@ class MemberSignupCreatesUserTests(TestCase):
                 "primary_instrument": self.instrument.pk,
             },
         )
-        # Set-password email should have been sent
-        self.assertTrue(
-            any("/member/set-password/" in m.body for m in mail.outbox),
-            "Expected a set-password email but none found",
-        )
+        # Welcome email with set-password link should have been sent to member only
+        welcome_emails = [m for m in mail.outbox if "http://testserver/member/set-password/" in m.body]
+        self.assertTrue(welcome_emails, "Expected a welcome email with a valid set-password URL but none found")
+        welcome = welcome_emails[0]
+        self.assertEqual(welcome.to, ["alex@example.com"])
+        self.assertNotIn("info@blowcomotion.com", welcome.to)
+        # Both steps should be present
+        self.assertIn("gig-o-matic.com", welcome.body)
         # A User linked to the new Member should exist
         from blowcomotion.models import Member
         member = Member.objects.get(email="alex@example.com")

--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -32,7 +32,7 @@ from blowcomotion.forms import (
 from blowcomotion.member_auth import (
     _MemberEmail,
     create_member_user,
-    send_set_password_email,
+    send_member_signup_welcome_email,
 )
 from blowcomotion.models import (
     AttendanceRecord,
@@ -748,14 +748,14 @@ def _process_member_signup(request, form_data):
                 # Log the error but don't fail the signup
                 logger.warning(f"Error sending GO3 band invite: {str(e)}")
 
-        # Create a User account and send set-password email if the member has an email
+        # Create a User account and send welcome email with set-password link and next steps
         if member.email:
             try:
                 create_member_user(member)
-                send_set_password_email(member, f"{request.scheme}://{request.get_host()}")
-                logger.info(f"Sent set-password email to new member {member.pk}")
+                send_member_signup_welcome_email(member, f"{request.scheme}://{request.get_host()}")
+                logger.info(f"Sent signup welcome email to new member {member.pk}")
             except Exception as e:
-                logger.warning(f"Could not send set-password email to new member {member.pk}: {e}")
+                logger.warning(f"Could not send welcome email to new member {member.pk}: {e}")
 
         # Send email notification to admin
         if recipients:
@@ -814,27 +814,6 @@ Name: {member.first_name} {member.last_name}"""
                 logger.error(f"Error sending admin notification email: {str(e)}")
         else:
             logger.warning("No member signup notification recipients configured in site settings.")
-        
-        # Send confirmation email to new member if they provided an email
-        if member.email:
-            try:
-                confirmation_message = f"""Hello {member.first_name},
-
-Thank you for signing up with Blowcomotion! You've been added to our band.
-
-Please check your email, look for an email from "superuser@gig-o-matic.com" and complete the registration process there.
-
-Start Wearing Purple,
-Blowcomotion"""
-                
-                _send_form_email(
-                    subject='Welcome to Blowcomotion - Application Received',
-                    message=confirmation_message,
-                    recipient_list=[member.email, "info@blowcomotion.com"]
-                )
-                logger.info(f"Confirmation email sent to {member.email}")
-            except Exception as e:
-                logger.error(f"Error sending confirmation email: {str(e)}")
         
         return {
             'message': 'Thank you for signing up! We have received your information and will be in touch soon. Please check your email for next steps.',


### PR DESCRIPTION
## Summary

- `MemberViewSet.search_fields` used plain string field names (`"first_name"`, `"last_name"`, etc.), which Wagtail forwarded as `fields=` to the modelsearch backend
- The SQLite FTS backend treated these as FTS column names, but that table only has `title`, `body`, `autocomplete` — hence `no such column: first_name`
- Production (MySQL) handled the `fields=` parameter differently (mapping to `index.SearchField` objects), so the bug only surfaced locally

## Fix

- Set `search_fields = None` on `MemberViewSet` so Wagtail uses the model's `index.SearchField` definitions directly
- Trimmed `Member.search_fields` to the five fields relevant for admin member lookup (`first_name`, `last_name`, `preferred_name`, `gigomatic_username`, `email`), removing `bio`, `phone`, `address`, `city`, `state`, `zip_code`, `country`, `notes`
- Removed a stale comment that described a workaround that was no longer in effect

## Test plan

- [ ] Open the Wagtail admin member list and search for a member by name — should return results without error
- [ ] Confirm search works on both SQLite (local) and MySQL (production)