### PR TITLE
feat: add submit button spinner to member signup form

### DIFF
--- a/blowcomotion/static/css/member-signup-form.css
+++ b/blowcomotion/static/css/member-signup-form.css
@@ -28,13 +28,3 @@
 .member-signup-form h4 i {
     margin-right: 0.5rem;
 }
-
-/* Submit spinner — shown while HTMX request is in flight */
-.member-signup-form .htmx-request .htmx-indicator {
-    display: inline-block !important;
-}
-
-.member-signup-form .htmx-request button[type="submit"] {
-    opacity: 0.6;
-    pointer-events: none;
-}

--- a/blowcomotion/static/css/member-signup-form.css
+++ b/blowcomotion/static/css/member-signup-form.css
@@ -28,3 +28,13 @@
 .member-signup-form h4 i {
     margin-right: 0.5rem;
 }
+
+/* Submit spinner — shown while HTMX request is in flight */
+.member-signup-form .htmx-request .htmx-indicator {
+    display: inline-block !important;
+}
+
+.member-signup-form .htmx-request button[type="submit"] {
+    opacity: 0.6;
+    pointer-events: none;
+}

--- a/blowcomotion/templates/blocks/member_signup_form_block.html
+++ b/blowcomotion/templates/blocks/member_signup_form_block.html
@@ -26,7 +26,7 @@
 
             <div class="card shadow-sm">
                 <div class="card-body p-4">
-                    <form hx-post="{% url 'process-form' %}" name="member-signup-form">
+                    <form hx-post="{% url 'process-form' %}" name="member-signup-form" hx-indicator="#signup-submit-spinner">
                         {% csrf_token %}
                         <input type="hidden" name="form_type" value="member_signup_form">
 
@@ -232,7 +232,7 @@
                         <!-- Submit Button -->
                         <div class="text-center">
                             <button type="submit" class="site-btn btn-lg px-5">
-                                <span class="htmx-indicator spinner-border spinner-border-sm me-2" style="display: none;"></span>
+                                <span id="signup-submit-spinner" class="htmx-indicator spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
                                 <i class="fa fa-paper-plane"></i> {{ value.button_text|default:"Submit Application" }}
                             </button>
                         </div>

--- a/blowcomotion/templates/blocks/member_signup_form_block.html
+++ b/blowcomotion/templates/blocks/member_signup_form_block.html
@@ -232,6 +232,7 @@
                         <!-- Submit Button -->
                         <div class="text-center">
                             <button type="submit" class="site-btn btn-lg px-5">
+                                <span class="htmx-indicator spinner-border spinner-border-sm me-2" style="display: none;"></span>
                                 <i class="fa fa-paper-plane"></i> {{ value.button_text|default:"Submit Application" }}
                             </button>
                         </div>


### PR DESCRIPTION
Closes #239

## Summary

- Adds a Bootstrap spinner (`spinner-border spinner-border-sm`) inside the signup form submit button
- The spinner is hidden by default and shown via HTMX's automatic `htmx-request` class while the form request is in flight
- The submit button is also disabled (opacity 0.6, pointer-events none) during submission to prevent double-clicks
- Follows the existing htmx-indicator pattern used in the attendance UI

## Test plan

- Visit a page containing the member signup form block
- Fill out the form and click "Submit Application"
- Confirm a spinner appears inside the button while the request is processing
- Confirm the button is not clickable during submission
- Confirm normal button state is restored after response