### PR TITLE
fix: redirect duplicate-email signup to login page

### DIFF
--- a/blowcomotion/templates/forms/signup_duplicate_email.html
+++ b/blowcomotion/templates/forms/signup_duplicate_email.html
@@ -1,0 +1,3 @@
+<div class="alert alert-info" role="alert">
+    An account with this email already exists. Please <a href="{% url 'member-login' %}">log in</a> instead.
+</div>

--- a/blowcomotion/tests/test_member_signup_go3.py
+++ b/blowcomotion/tests/test_member_signup_go3.py
@@ -497,3 +497,71 @@ class MemberSignupCreatesUserTests(TestCase):
         self.assertIsNotNone(member.user_id)
         user = User.objects.get(pk=member.user_id)
         self.assertFalse(user.has_usable_password())
+
+
+class MemberSignupDuplicateEmailTests(TestCase):
+    """Signing up with an email that already belongs to a member shows a login prompt."""
+
+    def setUp(self):
+        self.client = Client()
+        site = Site.objects.get(is_default_site=True)
+        SiteSettings.objects.create(
+            site=site,
+            member_signup_notification_recipients='admin@example.com',
+        )
+        section = Section.objects.create(name="Test Section")
+        self.instrument = Instrument.objects.create(name="Trumpet", section=section)
+        # Pre-existing member with this email
+        Member.objects.create(
+            first_name="Existing",
+            last_name="Member",
+            email="existing@example.com",
+            is_active=True,
+        )
+
+    @override_settings(
+        GIGO_API_URL=None,
+        DEBUG=True,
+        RECAPTCHA_PUBLIC_KEY=None,
+        RECAPTCHA_PRIVATE_KEY=None,
+    )
+    def test_duplicate_email_shows_login_prompt(self):
+        """A signup attempt with a registered email renders the login-prompt partial."""
+        response = self.client.post(
+            reverse('process-form'),
+            {
+                'form_type': 'member_signup_form',
+                'first_name': 'New',
+                'last_name': 'Person',
+                'email': 'existing@example.com',
+                'primary_instrument': self.instrument.pk,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn('An account with this email already exists', content)
+        self.assertIn('/member/login/', content)
+        # No second Member record should have been created
+        self.assertEqual(Member.objects.filter(email='existing@example.com').count(), 1)
+
+    @override_settings(
+        GIGO_API_URL=None,
+        DEBUG=True,
+        RECAPTCHA_PUBLIC_KEY=None,
+        RECAPTCHA_PRIVATE_KEY=None,
+    )
+    def test_duplicate_email_case_insensitive(self):
+        """Duplicate email check is case-insensitive."""
+        response = self.client.post(
+            reverse('process-form'),
+            {
+                'form_type': 'member_signup_form',
+                'first_name': 'New',
+                'last_name': 'Person',
+                'email': 'EXISTING@EXAMPLE.COM',
+                'primary_instrument': self.instrument.pk,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('An account with this email already exists', response.content.decode())
+        self.assertEqual(Member.objects.filter(email__iexact='existing@example.com').count(), 1)

--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -696,7 +696,16 @@ def _process_member_signup(request, form_data):
     
     try:
         primary_instrument = form_data.get('primary_instrument')  # Already an Instrument object from MemberSignupForm
-        
+
+        # Check for duplicate email before attempting to create a member.
+        # Email is the login identifier, so a match means the person already has an account.
+        email = form_data.get('email')
+        if email and Member.objects.filter(email__iexact=email).exists():
+            logger.info(f"Member signup rejected: email already registered ({email})")
+            return {
+                'template': 'forms/signup_duplicate_email.html',
+            }
+
         # Create new member from form data
         member = Member(
             first_name=form_data['first_name'],


### PR DESCRIPTION
## Summary

- When a user submits `/member-signup/` with an email that already belongs to a member, they now see a friendly message: "An account with this email already exists. Please log in instead." with a link to `/member/login/`
- The duplicate check runs before `Member.full_clean()`, so the new message is shown in place of the generic name-based validation error that was previously surfaced (the one from `Member.clean()`)
- The check is case-insensitive (`email__iexact`) to match the rest of the codebase's email comparison convention

## Notes

The existing name-uniqueness check in `Member.clean()` is intentionally unchanged. It is a general data-integrity guard used by the Wagtail admin snippet as well as the public signup flow. A genuinely-new person who shares a name but uses a different email will still hit that error during signup -- this is a separate product decision (allowing duplicate-name public signups) that is out of scope here.

## Test plan

- [x] `test_duplicate_email_shows_login_prompt` -- POST with a registered email renders the login-prompt partial and creates no second Member
- [x] `test_duplicate_email_case_insensitive` -- same behaviour with `EXISTING@EXAMPLE.COM` vs stored `existing@example.com`
- [x] All 20 tests in `test_member_signup_go3` pass

Closes #238