### PR TITLE
feat: add download button to jukebox and chart library blocks

### DIFF
--- a/blowcomotion/static/css/chart-library.css
+++ b/blowcomotion/static/css/chart-library.css
@@ -307,7 +307,7 @@ a.accordion-part:hover .part-pdf-icon {
 .song-media-icons {
     display: flex;
     flex-shrink: 0;
-    width: 56px;
+    width: 84px;
     margin-right: 8px;
 }
 
@@ -337,6 +337,25 @@ a.accordion-part:hover .part-pdf-icon {
 
 .song-play-btn.playing {
     color: #28a745;
+}
+
+/* ===== Download Button ===== */
+.song-download-btn {
+    background: none;
+    border: none;
+    padding: 4px;
+    color: #666;
+    font-size: 16px;
+    line-height: 1;
+    text-decoration: none;
+    transition: color 0.15s ease, transform 0.15s ease;
+    display: inline-flex;
+    align-items: center;
+}
+
+.song-download-btn:hover {
+    color: #5b1a76;
+    transform: scale(1.1);
 }
 
 /* ===== Video Button ===== */
@@ -550,15 +569,16 @@ a.accordion-part:hover .part-pdf-icon {
     }
     
     .song-media-icons {
-        width: 48px;
+        width: 72px;
         margin-right: 6px;
     }
-    
+
     .media-icon-slot {
         width: 24px;
     }
-    
+
     .song-play-btn,
+    .song-download-btn,
     .song-video-btn {
         font-size: 16px;
     }

--- a/blowcomotion/static/js/chart-library.js
+++ b/blowcomotion/static/js/chart-library.js
@@ -350,6 +350,13 @@
                                 ` : ''}
                             </span>
                             <span class="media-icon-slot">
+                                ${song.has_recording ? `
+                                    <a href="${this.escapeHtml(song.recording_url)}" download="${this.escapeHtml(song.title)}.mp3" class="song-download-btn" title="Download ${this.escapeHtml(song.title)}" aria-label="Download ${this.escapeHtml(song.title)}">
+                                        <i class="fa fa-download"></i>
+                                    </a>
+                                ` : ''}
+                            </span>
+                            <span class="media-icon-slot">
                                 ${this.renderVideoButtons(song)}
                             </span>
                         </span>

--- a/blowcomotion/static/scss/_home-page.scss
+++ b/blowcomotion/static/scss/_home-page.scss
@@ -243,7 +243,8 @@
 
 .jp-download-btn-wrap {
   float: left;
-  padding-top: 20px;
+  padding-left: 12px;
+  padding-top: 25px;
 }
 
 .jp-download-btn {

--- a/blowcomotion/static/scss/_home-page.scss
+++ b/blowcomotion/static/scss/_home-page.scss
@@ -241,6 +241,22 @@
   padding-top: 25px;
 }
 
+.jp-download-btn-wrap {
+  float: left;
+  padding-top: 20px;
+}
+
+.jp-download-btn {
+  color: $heading-color;
+  font-size: 18px;
+  text-decoration: none;
+  transition: color 0.15s ease;
+
+  &:hover {
+    color: $primary-color;
+  }
+}
+
 .single_player_container {
   overflow: hidden;
   margin-bottom: 40px;

--- a/blowcomotion/templates/blocks/jukebox_block.html
+++ b/blowcomotion/templates/blocks/jukebox_block.html
@@ -67,6 +67,10 @@
                                                 <div class="jp-volume-bar-value" style="width: 0%;"></div>
                                             </div>
                                         </div>
+                                        <!-- Download -->
+                                        <div class="jp-download-btn-wrap">
+                                            <a href="{{ track.recording.file.url }}" download="{{ track.title }}.mp3" class="jp-download-btn" title="Download {{ track.title }}" aria-label="Download {{ track.title }}"><i class="fa fa-download"></i></a>
+                                        </div>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary

Closes #184.

- **JukeBoxBlock** (`jukebox_block.html`): adds a download `<a>` element with the `download` attribute next to the volume controls for each track that has a recording. The suggested filename is derived from the track title.
- **ChartLibraryBlock** (`chart-library.js`): adds a download button in a third `media-icon-slot` next to the play button for every song row that has a recording. The `recording_url` field is already present in the API response so no backend changes are needed.
- **Styling** (`chart-library.css`, `_home-page.scss`): new `.song-download-btn` and `.jp-download-btn` rules using the site's Font Awesome `fa-download` icon, consistent with the adjacent play/video icon style. The `.song-media-icons` container is widened from 56 px to 84 px to accommodate the additional slot.

Files are served from the same origin (`MEDIA_URL = "/media/"`, `FileSystemStorage`), so the HTML `download` attribute triggers a true file download.

## Test plan

- [ ] On a page with the JukeBoxBlock, confirm a download icon appears next to the volume controls on each track that has a recording, and that clicking it downloads the mp3 rather than opening it in the browser.
- [ ] On a page with the ChartLibraryBlock, expand a section and instrument, confirm a download icon appears next to the play button for each song with a recording, and that clicking it downloads the mp3.
- [ ] Confirm songs/tracks without recordings show no download icon.
- [ ] Verify responsive layout at mobile width: icons remain aligned and usable.