### PR TITLE
fix: resolve Wagtail accessibility checker violations across templates

### DIFF
--- a/blowcomotion/static/css/video-feed.css
+++ b/blowcomotion/static/css/video-feed.css
@@ -45,7 +45,7 @@
     z-index: 1;
 }
 
-.video-feed__featured-text h4 {
+.video-feed__featured-text h3 {
     color: #ffffff;
     font-weight: 700;
     margin-bottom: 10px;
@@ -114,7 +114,7 @@
     position: absolute;
 }
 
-.video-feed__item-text h5 {
+.video-feed__item-text h3 {
     font-weight: 700;
     color: #111111;
     margin-bottom: 8px;

--- a/blowcomotion/static/js/main.js
+++ b/blowcomotion/static/js/main.js
@@ -44,7 +44,7 @@
         items: 3,
         dots: false,
         nav: true,
-        navText: ["<i class='fa fa-angle-left'></i>","<i class='fa fa-angle-right'></i>"],
+        navText: ["<i class='fa fa-angle-left' aria-hidden='true'></i>","<i class='fa fa-angle-right' aria-hidden='true'></i>"],
         smartSpeed: 1200,
         autoHeight: false,
         autoplay: true,
@@ -60,6 +60,8 @@
             },
         }
     });
+    $(".event__slider .owl-prev").attr("aria-label", "Previous");
+    $(".event__slider .owl-next").attr("aria-label", "Next");
     
     /*--------------------------
         Videos Slider
@@ -70,7 +72,7 @@
         items: 4,
         dots: false,
         nav: true,
-        navText: ["<i class='fa fa-angle-left'></i>","<i class='fa fa-angle-right'></i>"],
+        navText: ["<i class='fa fa-angle-left' aria-hidden='true'></i>","<i class='fa fa-angle-right' aria-hidden='true'></i>"],
         smartSpeed: 1200,
         autoHeight: false,
         autoplay: true,
@@ -89,6 +91,8 @@
             }
         }
     });
+    $(".videos__slider .owl-prev").attr("aria-label", "Previous");
+    $(".videos__slider .owl-next").attr("aria-label", "Next");
 
     /*--------------------------
         Image Carousel Slider
@@ -107,7 +111,7 @@
             dots: showDots,
             dotsEach: false,
             nav: true,
-            navText: ["<i class='fa fa-angle-left'></i>","<i class='fa fa-angle-right'></i>"],
+            navText: ["<i class='fa fa-angle-left' aria-hidden='true'></i>","<i class='fa fa-angle-right' aria-hidden='true'></i>"],
             smartSpeed: 1200,
             autoHeight: false,
             autoplay: autoplay,
@@ -134,6 +138,11 @@
         };
         
         $slider.owlCarousel(owlConfig);
+        $slider.find(".owl-prev").attr("aria-label", "Previous");
+        $slider.find(".owl-next").attr("aria-label", "Next");
+        $slider.find(".owl-dot").each(function(i) {
+            $(this).attr("aria-label", "Slide " + (i + 1));
+        });
     });
 
     /*------------------

--- a/blowcomotion/static/scss/_base.scss
+++ b/blowcomotion/static/scss/_base.scss
@@ -127,7 +127,8 @@ ol {
     text-transform: uppercase;
   }
 
-  h1 {
+  h1,
+  .section-bg-text {
     font-size: 100px;
     color: #f2f2f2;
     font-family: 'Rockville Solid Regular';

--- a/blowcomotion/static/scss/_responsive.scss
+++ b/blowcomotion/static/scss/_responsive.scss
@@ -304,7 +304,8 @@
   
   /* Small Device = 320px */
   @media only screen and (max-width: 479px) {
-    .section-title h1 {
+    .section-title h1,
+    .section-title .section-bg-text {
       top: -40px;
       font-size: 79px;
       line-height: 0.8;
@@ -322,7 +323,7 @@
       font-size: 50px;
     }
   
-    .single_player_container h4 {
+    .single_player_container h3 {
       font-size: 16px;
     }
   

--- a/blowcomotion/templates/blocks/hero_block.html
+++ b/blowcomotion/templates/blocks/hero_block.html
@@ -10,7 +10,7 @@
                         {% if value.middle_line %}<h1>{{ value.middle_line }}</h1>{% endif %}
                         {% if value.bottom_line %}<p>{{ value.bottom_line }}</p>{% endif %}
                         {% if value.youtube_url %}
-                            <a href="#" class="play-btn video-popup-trigger" data-video-url="{{ youtube_embed_url }}"><i class="fa fa-play"></i></a>
+                            <a href="#" class="play-btn video-popup-trigger" data-video-url="{{ youtube_embed_url }}" aria-label="Play video"><i class="fa fa-play"></i></a>
                         {% endif %}
                     </div>
                 </div>

--- a/blowcomotion/templates/blocks/image_carousel_block.html
+++ b/blowcomotion/templates/blocks/image_carousel_block.html
@@ -13,7 +13,7 @@
                     <h2 class="text-uppercase text-muted">{{ value.subtitle }}</h2>
                     {% endif %}
                     {% if value.title %}
-                    <h1>{{ value.title }}</h1>
+                    <span class="section-bg-text">{{ value.title }}</span>
                     {% endif %}
                 </div>
                 {% endif %}

--- a/blowcomotion/templates/blocks/jukebox_block.html
+++ b/blowcomotion/templates/blocks/jukebox_block.html
@@ -7,7 +7,7 @@
             <div class="col-lg-12">
                 <div class="section-title">
                     <h2>{{ value.foreground_text }}</h2>
-                    <h1>{{ value.background_text }}</h1>
+                    <span class="section-bg-text">{{ value.background_text }}</span>
                 </div>
             </div>
             {% comment %} <div class="col-lg-5">
@@ -22,7 +22,7 @@
                     {% for track in value.tracks %}
                         {% if track.recording and track.recording.file.url %}
                             <div class="single_player_container" data-track-id="{{ forloop.counter }}">
-                                <h4>{{ track.title }}</h4>
+                                <h3>{{ track.title }}</h3>
                                 {% if value.lazy_loading %}
                                     <div class="jp-jplayer jplayer lazy-player" 
                                          data-ancestor=".jp_container_{{ forloop.counter }}"
@@ -39,11 +39,11 @@
                                         <!-- Player Controls -->
                                         <div class="player_controls_box">
                                             {% if value.lazy_loading %}
-                                                <button class="jp-play player_button lazy-play-btn" tabindex="0" data-track-id="{{ forloop.counter }}">
+                                                <button class="jp-play player_button lazy-play-btn" tabindex="0" data-track-id="{{ forloop.counter }}" aria-label="Play {{ track.title }}">
                                                     <span class="loading-spinner" style="display: none;">⟳</span>
                                                 </button>
                                             {% else %}
-                                                <button class="jp-play player_button" tabindex="0"></button>
+                                                <button class="jp-play player_button" tabindex="0" aria-label="Play {{ track.title }}"></button>
                                             {% endif %}
                                             <a href="{{ track.recording.file.url }}" download="{{ track.title }}.mp3" class="jp-download-btn" title="Download {{ track.title }}" aria-label="Download {{ track.title }}"><i class="fa fa-download"></i></a>
                                         </div>
@@ -63,8 +63,8 @@
                                         </div>
                                         <!-- Volume Controls -->
                                         <div class="jp-volume-controls">
-                                            <button class="jp-mute" tabindex="0"><i
-                                                    class="fa fa-volume-down"></i></button>
+                                            <button class="jp-mute" tabindex="0" aria-label="Mute"><i
+                                                    class="fa fa-volume-down" aria-hidden="true"></i></button>
                                             <div class="jp-volume-bar">
                                                 <div class="jp-volume-bar-value" style="width: 0%;"></div>
                                             </div>
@@ -74,7 +74,7 @@
                             </div>
                         {% else %}
                             <div class="single_player_container">
-                                <h4>{{ track.title }}</h4>
+                                <h3>{{ track.title }}</h3>
                                 <p>Recording not available</p>
                             </div>
                         {% endif %}

--- a/blowcomotion/templates/blocks/member_signup_form_block.html
+++ b/blowcomotion/templates/blocks/member_signup_form_block.html
@@ -32,9 +32,9 @@
 
                         <!-- Personal Information Section -->
                         <div class="mb-4">
-                            <h4 class="border-bottom pb-2 mb-3">
+                            <h2 class="border-bottom pb-2 mb-3 h4">
                                 <i class="fa fa-user"></i> Personal Information
-                            </h4>
+                            </h2>
                             
                             <div class="row">
                                 <div class="col-md-6 mb-3">
@@ -76,9 +76,9 @@
 
                         <!-- Birthday Section -->
                         <div class="mb-4">
-                            <h4 class="border-bottom pb-2 mb-3">
+                            <h2 class="border-bottom pb-2 mb-3 h4">
                                 <i class="fa fa-birthday-cake"></i> Birthday
-                            </h4>
+                            </h2>
                             
                             <div class="row">
                                 <div class="col-md-4 mb-3">
@@ -120,9 +120,9 @@
 
                         <!-- Contact Information Section -->
                         <div class="mb-4">
-                            <h4 class="border-bottom pb-2 mb-3">
+                            <h2 class="border-bottom pb-2 mb-3 h4">
                                 <i class="fa fa-envelope"></i> Contact Information
-                            </h4>
+                            </h2>
                             
                             <div class="row">
                                 <div class="col-md-6 mb-3">
@@ -144,9 +144,9 @@
 
                         <!-- Address Section -->
                         <div class="mb-4">
-                            <h4 class="border-bottom pb-2 mb-3">
+                            <h2 class="border-bottom pb-2 mb-3 h4">
                                 <i class="fa fa-home"></i> Address
-                            </h4>
+                            </h2>
                             
                             <div class="mb-3">
                                 <label for="address" class="form-label">
@@ -190,9 +190,9 @@
 
                         <!-- Emergency Contact Section -->
                         <div class="mb-4">
-                            <h4 class="border-bottom pb-2 mb-3">
+                            <h2 class="border-bottom pb-2 mb-3 h4">
                                 <i class="fa fa-phone"></i> Emergency Contact
-                            </h4>
+                            </h2>
                             
                             <div class="mb-3">
                                 <label for="emergency_contact" class="form-label">
@@ -205,9 +205,9 @@
 
                         <!-- Inspiration Section -->
                         <div class="mb-4">
-                            <h4 class="border-bottom pb-2 mb-3">
+                            <h2 class="border-bottom pb-2 mb-3 h4">
                                 <i class="fa fa-lightbulb-o"></i> Your Story
-                            </h4>
+                            </h2>
                             
                             <div class="mb-3">
                                 <label for="inspired_by" class="form-label">
@@ -220,9 +220,9 @@
 
                         <!-- Shirt Size Section -->
                         <div class="mb-4">
-                            <h4 class="border-bottom pb-2 mb-3">
+                            <h2 class="border-bottom pb-2 mb-3 h4">
                                 <i class="fa fa-shopping-bag"></i> Shirt Size
-                            </h4>
+                            </h2>
                             <div class="mb-3">
                                 <label for="shirt_size" class="form-label">All Adult UniSex</label>
                                 <select class="form-control" id="shirt_size" name="shirt_size">
@@ -235,9 +235,9 @@
 
                         <!-- Dietary Preferences Section -->
                         <div class="mb-4">
-                            <h4 class="border-bottom pb-2 mb-3">
+                            <h2 class="border-bottom pb-2 mb-3 h4">
                                 <i class="fa fa-cutlery"></i> Dietary Preferences/Practices
-                            </h4>
+                            </h2>
                             <p class="text-muted small mb-3">Select all that apply.</p>
                             <div class="row">
                                 {% for value_label in dietary_choices %}
@@ -263,9 +263,9 @@
 
                         <!-- Allergy Section -->
                         <div class="mb-4">
-                            <h4 class="border-bottom pb-2 mb-3">
+                            <h2 class="border-bottom pb-2 mb-3 h4">
                                 <i class="fa fa-exclamation-triangle"></i> Allergies
-                            </h4>
+                            </h2>
                             <div class="mb-3">
                                 <label for="has_allergies" class="form-label">Do you have any food allergies?</label>
                                 <select class="form-control" id="has_allergies" name="has_allergies">
@@ -318,9 +318,9 @@
 
                         <!-- Confidential Medical Notes Section -->
                         <div class="mb-4">
-                            <h4 class="border-bottom pb-2 mb-3">
+                            <h2 class="border-bottom pb-2 mb-3 h4">
                                 <i class="fa fa-lock"></i> Confidential Medical Information
-                            </h4>
+                            </h2>
                             <div class="mb-3">
                                 <label for="medical_notes" class="form-label">
                                     CONFIDENTIAL: Any medical concerns or allergies

--- a/blowcomotion/templates/blocks/timeline_item_block.html
+++ b/blowcomotion/templates/blocks/timeline_item_block.html
@@ -10,7 +10,7 @@
     {% endif %}
     <div class="card-header p-0 border-0">
       <button class="btn btn-link w-100 text-left text-decoration-none text-dark p-4" type="button" data-toggle="collapse" data-target="#collapse-{{ value.id }}-{{ forloop.counter }}" aria-expanded="false" aria-controls="collapse-{{ value.id }}-{{ forloop.counter }}" >
-        <h4 class="font-weight-bold mb-2">{{ item.title }}{% if item.has_longtext %} (has long text){% endif %}</h4>
+        <h3 class="font-weight-bold mb-2">{{ item.title }}{% if item.has_longtext %} (has long text){% endif %}</h3>
         {% if item.date %}
         <small class="text-muted text-sm mb-0"><i class="far fa-clock" aria-hidden="true"></i> {{ item.date }}</small>
         {% endif %}
@@ -32,7 +32,7 @@
         </div>
       {% endif %}
       <div class="card-header p-4 border-0">
-        <h4 class="font-weight-bold mb-2">{{ item.title }}</h4>
+        <h3 class="font-weight-bold mb-2">{{ item.title }}</h3>
         {% if item.date %}
           <small class="text-muted text-sm mb-0"><i class="far fa-clock" aria-hidden="true"></i> {{ item.date }}</small>
         {% endif %}

--- a/blowcomotion/templates/blocks/video_feed_block.html
+++ b/blowcomotion/templates/blocks/video_feed_block.html
@@ -13,7 +13,7 @@
                     <h2 class="text-uppercase text-muted">{{ value.subtitle }}</h2>
                     {% endif %}
                     {% if value.title %}
-                    <h1>{{ value.title }}</h1>
+                    <span class="section-bg-text">{{ value.title }}</span>
                     {% endif %}
                 </div>
                 {% endif %}
@@ -36,11 +36,11 @@
                         {% else %}
                             <div class="video-feed__thumbnail-placeholder bg-dark" style="padding-top: 56.25%;"></div>
                         {% endif %}
-                        <a href="#" class="play-btn"><i class="fa fa-play"></i></a>
+                        <a href="#" class="play-btn" aria-label="Play {{ featured_video.overrides.title_override|default:featured_video.title }}"><i class="fa fa-play"></i></a>
                         {% if featured_video.overrides.title_override or featured_video.title or featured_video.overrides.description %}
                         <div class="video-feed__featured-text">
                             {% if featured_video.overrides.title_override or featured_video.title %}
-                            <h4>{{ featured_video.overrides.title_override|default:featured_video.title }}</h4>
+                            <h3>{{ featured_video.overrides.title_override|default:featured_video.title }}</h3>
                             {% endif %}
                             {% if featured_video.overrides.description %}
                             <ul>
@@ -75,12 +75,12 @@
                                     {% else %}
                                         <div class="video-feed__thumbnail-placeholder bg-dark" style="padding-top: 56.25%;"></div>
                                     {% endif %}
-                                    <a href="#" class="play-btn"><i class="fa fa-play"></i></a>
+                                    <a href="#" class="play-btn" aria-label="Play {{ video.overrides.title_override|default:video.title }}"><i class="fa fa-play"></i></a>
                                 </div>
                                 {% if video.overrides.title_override or video.title or video.overrides.description %}
                                 <div class="video-feed__item-text">
                                     {% if video.overrides.title_override or video.title %}
-                                    <h5>{{ video.overrides.title_override|default:video.title }}</h5>
+                                    <h3>{{ video.overrides.title_override|default:video.title }}</h3>
                                     {% endif %}
                                     {% if video.overrides.description %}
                                     <ul>

--- a/blowcomotion/templates/footer.html
+++ b/blowcomotion/templates/footer.html
@@ -9,7 +9,7 @@
                             <li>
                                 <i class="fa fa-envelope"></i>
                                 <p>Email</p>
-                                <h6>{{ settings.blowcomotion.SiteSettings.email }}</h6>
+                                <p class="h6">{{ settings.blowcomotion.SiteSettings.email }}</p>
                             </li>
                         </ul>
                     </div>
@@ -19,9 +19,9 @@
                 <div class="footer__social">
                     {% if settings.blowcomotion.SiteSettings.footer_text %}<h2>{{ settings.blowcomotion.SiteSettings.footer_text }}</h2>{% endif %}
                     <div class="footer__social__links">
-                        {% if settings.blowcomotion.SiteSettings.facebook %}<a href="{{ settings.blowcomotion.SiteSettings.facebook }}"><i class="fa fa-facebook"></i></a>{% endif %}
-                        {% if settings.blowcomotion.SiteSettings.twitter %}<a href="{{ settings.blowcomotion.SiteSettings.twitter }}"><i class="fa fa-twitter"></i></a>{% endif %}
-                        {% if settings.blowcomotion.SiteSettings.instagram %}<a href="{{ settings.blowcomotion.SiteSettings.instagram }}"><i class="fa fa-instagram"></i></a>{% endif %}
+                        {% if settings.blowcomotion.SiteSettings.facebook %}<a href="{{ settings.blowcomotion.SiteSettings.facebook }}" aria-label="Facebook"><i class="fa fa-facebook"></i></a>{% endif %}
+                        {% if settings.blowcomotion.SiteSettings.twitter %}<a href="{{ settings.blowcomotion.SiteSettings.twitter }}" aria-label="Twitter"><i class="fa fa-twitter"></i></a>{% endif %}
+                        {% if settings.blowcomotion.SiteSettings.instagram %}<a href="{{ settings.blowcomotion.SiteSettings.instagram }}" aria-label="Instagram"><i class="fa fa-instagram"></i></a>{% endif %}
                     </div>
                 </div>
             </div>

--- a/blowcomotion/templates/header.html
+++ b/blowcomotion/templates/header.html
@@ -5,7 +5,7 @@
             <div class="col-lg-2 col-md-2">
                 <div class="header__logo">
                     {% with logo=settings.blowcomotion.SiteSettings.logo %}
-                        <a href='/'>{% image logo original class="img-fluid" %}</a>
+                        <a href='/' aria-label="Home">{% image logo original class="img-fluid" %}</a>
                     {% endwith %}
                 </div>
             </div>
@@ -47,8 +47,8 @@
                     </nav>
                     {% if settings.blowcomotion.SiteSettings.facebook or settings.blowcomotion.SiteSettings.instagram %}
                         <div class="header__right__social">
-                            {% if settings.blowcomotion.SiteSettings.facebook %}<a href="{{ settings.blowcomotion.SiteSettings.facebook }}"><i class="fa fa-facebook"></i></a>{% endif %}
-                            {% if settings.blowcomotion.SiteSettings.instagram %}<a href="{{ settings.blowcomotion.SiteSettings.instagram }}"><i class="fa fa-instagram"></i></a>{% endif %}
+                            {% if settings.blowcomotion.SiteSettings.facebook %}<a href="{{ settings.blowcomotion.SiteSettings.facebook }}" aria-label="Facebook"><i class="fa fa-facebook"></i></a>{% endif %}
+                            {% if settings.blowcomotion.SiteSettings.instagram %}<a href="{{ settings.blowcomotion.SiteSettings.instagram }}" aria-label="Instagram"><i class="fa fa-instagram"></i></a>{% endif %}
                         </div>
                     {% endif %}
                     <div class="header__member-auth ms-3">


### PR DESCRIPTION
Closes #269

## Summary

- Added `aria-label` to all icon-only links and buttons (logo, social links, play buttons, carousel nav, jukebox controls)
- Replaced decorative `<h1>` background text in section titles with `<span class="section-bg-text">` to remove false h1s from the heading hierarchy; updated SCSS to match
- Fixed heading-order skips in video feed, jukebox, timeline, member signup, and footer templates
- Converted footer email `<h6>` to `<p class="h6">` to remove it from the heading hierarchy
- Added `aria-label="Slide N"` to Owl Carousel dot buttons

## Test plan

- [ ] Browse homepage as admin, verify Wagtail content checker count is 0
- [ ] Check `/about/recordings/` — jukebox play/mute buttons and carousel dots should have no violations
- [ ] Check `/workshop-with-the-original-pinettes/` — image carousel nav and dots clear
- [ ] Visually confirm section title background text (large decorative Rockville font) still renders correctly on pages using video feed, image carousel, and jukebox blocks
- [ ] In production CMS: update Square logo image title and remove empty heading on rainy rehearsal page (tracked in #269)