### PR TITLE
fix: exclude hidden library instruments from rental form counts and filter

### DIFF
--- a/blowcomotion/member_forms.py
+++ b/blowcomotion/member_forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.db.models import Count, Q
+from django.db.models import Count, Exists, OuterRef, Q
 
 from blowcomotion.forms import MemberSignupForm
 from blowcomotion.models import Instrument, LibraryInstrument, Member
@@ -121,10 +121,11 @@ class InstrumentRentalRequestForm(forms.Form):
         base_qs = Instrument.objects.filter(hide_from_rental=False).annotate(
             available_count=Count(
                 "library_inventory",
-                filter=Q(library_inventory__status=LibraryInstrument.STATUS_AVAILABLE),
+                filter=(Q(library_inventory__hide_from_rental=False) & Q(library_inventory__status=LibraryInstrument.STATUS_AVAILABLE)),
             )
         )
-        qs_first = base_qs.filter(library_inventory__isnull=False).distinct().order_by("name")
+        has_visible_inventory = LibraryInstrument.objects.filter(instrument=OuterRef("pk"), hide_from_rental=False)
+        qs_first = base_qs.filter(Exists(has_visible_inventory)).order_by("name")
         qs_optional = base_qs.order_by("name")
 
         def label_fn(obj):


### PR DESCRIPTION
Closes #274

## Summary
- Added `hide_from_rental=False` to the `Count` annotation filter so hidden `LibraryInstrument` objects are excluded from the available count displayed in dropdown labels
- Replaced `.filter(library_inventory__isnull=False).distinct()` on `qs_first` with an `Exists` correlated subquery — the old JOIN on the same table as the `Count` annotation was inflating counts (4 bass drums showed as 12 available)

## Test plan
- [x] Open the instrument rental request form and confirm counts match the library inventory admin
- [x] Mark a `LibraryInstrument` as hidden (`hide_from_rental=True`) and confirm its instrument type's count decrements
- [ ] Mark all `LibraryInstrument` objects for an instrument type as hidden and confirm that type disappears from the primary instrument dropdown
- [x] Confirm instrument types with `hide_from_rental=True` on the `Instrument` record itself are absent from all dropdowns