### PR TITLE
fix: don't HTML-encode special chars in plain-text rental emails

### DIFF
--- a/blowcomotion/templates/emails/instrument_rental_request_approved.txt
+++ b/blowcomotion/templates/emails/instrument_rental_request_approved.txt
@@ -5,7 +5,7 @@ Great news — your instrument rental request has been approved.
 Instrument assigned: {{ assigned_unit.instrument.name }} (Serial: {{ assigned_unit.serial_number }})
 
 Message from the library team:
-{{ admin_message }}
+{% autoescape off %}{{ admin_message }}{% endautoescape %}
 
 {% if patreon_url %}To support the instrument library, please ensure your Patreon {{ patreon_url }} membership is active before pickup, select "Instrument Rental (Band Members Only) - you have the option to donate more, but we require this for rentals:
 

--- a/blowcomotion/templates/emails/instrument_rental_request_denied.txt
+++ b/blowcomotion/templates/emails/instrument_rental_request_denied.txt
@@ -5,7 +5,7 @@ Thank you for your interest in renting a {{ instrument.name }}.
 After reviewing your request, we are unable to fulfill it at this time.
 
 Message from the library team:
-{{ admin_message }}
+{% autoescape off %}{{ admin_message }}{% endautoescape %}
 
 If you have any questions, please reach out to the instrument library team:
 {{ contact_emails }}

--- a/blowcomotion/tests/test_instrument_rental.py
+++ b/blowcomotion/tests/test_instrument_rental.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 from wagtail.models import Site
 
+from django.core import mail
 from django.db.models import Count, Q
 from django.test import TestCase
 
@@ -524,3 +525,25 @@ class RentalRequestsAdminViewTest(TestCase):
         )
         self.submission.refresh_from_db()
         self.assertEqual(self.submission.status, InstrumentRentalRequestSubmission.STATUS_APPROVED)
+
+    def test_approve_email_does_not_html_encode_special_chars(self):
+        self.client.post(
+            reverse("rental_request_review", args=[self.submission.pk]),
+            {"action": "approve", "unit": self.li.pk, "message": "You're all set & ready — bring your ID."},
+        )
+        self.assertEqual(len(mail.outbox), 1)
+        body = mail.outbox[0].body
+        self.assertIn("You're all set & ready", body)
+        self.assertNotIn("&#x27;", body)
+        self.assertNotIn("&amp;", body)
+
+    def test_deny_email_does_not_html_encode_special_chars(self):
+        self.client.post(
+            reverse("rental_request_review", args=[self.submission.pk]),
+            {"action": "deny", "message": "Sorry — no \"trumpet\" available right now."},
+        )
+        self.assertEqual(len(mail.outbox), 1)
+        body = mail.outbox[0].body
+        self.assertIn('no "trumpet"', body)
+        self.assertNotIn("&quot;", body)
+        self.assertNotIn("&#x27;", body)


### PR DESCRIPTION
## Summary

- Wrapped `{{ admin_message }}` in `{% autoescape off %}` in both plain-text rental email templates (`instrument_rental_request_approved.txt` and `instrument_rental_request_denied.txt`)
- Django's template engine applies HTML escaping by default even for `.txt` templates, causing characters like `'`, `&`, and `"` to appear as `&#x27;`, `&amp;`, and `&quot;` in outgoing emails
- Added two regression tests that assert literal special characters appear in the email body and HTML entities do not

## Test plan

- [ ] Run `python manage.py test blowcomotion.tests.test_instrument_rental` — all 54 tests pass
- [ ] Approve a rental request with a message containing `'`, `&`, or `"` and confirm the email arrives with literal characters intact
- [ ] Deny a rental request with the same and confirm the same

Closes #266

Local testing screenshot
<img width="629" height="208" alt="Screenshot 2026-06-27 at 9 51 22 PM" src="https://github.com/user-attachments/assets/ac4ffb0a-1454-4beb-83d8-165e625deb37" />
