### PR TITLE
feat: add backup_db management command for scheduled database backups

### DIFF
--- a/blowcomotion/management/commands/backup_db.py
+++ b/blowcomotion/management/commands/backup_db.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+from pathlib import Path
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+BACKUP_DIR = Path.home() / 'backups'
+KEEP = 7  # ponytail: fixed retention; add --keep arg when you need it
+
+
+class Command(BaseCommand):
+    help = 'Dump database to a timestamped JSON file and rotate old backups'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--output-dir',
+            default=str(BACKUP_DIR),
+            help=f'Directory to write backups (default: {BACKUP_DIR})',
+        )
+
+    def handle(self, *args, **options):
+        output_dir = Path(options['output_dir'])
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        timestamp = datetime.now().strftime('%Y-%m-%d_%H%M%S')
+        backup_path = output_dir / f'backup_{timestamp}.json'
+
+        self.stdout.write(f'Writing backup to {backup_path}')
+
+        with open(backup_path, 'w', encoding='utf-8') as f:
+            call_command(
+                'dumpdata',
+                '--natural-foreign',
+                '--indent', '2',
+                '--exclude', 'contenttypes',
+                '--exclude', 'auth.permission',
+                '--exclude', 'sessions',
+                '--exclude', 'wagtailsearch',
+                '--exclude', 'wagtailcore.referenceindex',
+                '--exclude', 'wagtailcore.taskstate',
+                '--exclude', 'wagtailcore.workflowstate',
+                '--exclude', 'wagtailcore.comment',
+                '--exclude', 'wagtailcore.groupcollectionpermission',
+                '--exclude', 'wagtailcore.grouppagepermission',
+                '--exclude', 'wagtailadmin.editingsession',
+                '--exclude', 'wagtailadmin.formstate',
+                '--exclude', 'wagtailusers.userprofile',
+                '--exclude', 'admin.logentry',
+                '--exclude', 'axes.accesslog',
+                stdout=f,
+                verbosity=0,
+            )
+
+        size_kb = backup_path.stat().st_size // 1024
+        self.stdout.write(self.style.SUCCESS(f'Backup complete: {backup_path} ({size_kb} KB)'))
+
+        # Rotate: delete oldest backups beyond KEEP
+        backups = sorted(output_dir.glob('backup_*.json'))
+        for old in backups[:-KEEP]:
+            old.unlink()
+            self.stdout.write(f'Deleted old backup: {old.name}')


### PR DESCRIPTION
## Summary

- Adds `backup_db` management command that dumps all data to a timestamped JSON file
- Excludes ephemeral/non-restorable tables (sessions, axes logs, wagtail search index, editing sessions)
- Keeps the 7 most recent backups, deleting older ones automatically
- Default output directory: `~/backups/`; override with `--output-dir`

## Schedule on PythonAnywhere

Add a daily scheduled task:
```
python /home/blowcomotion/blowcomotion.org/manage.py backup_db
```

## Test plan

- [ ] Run `python manage.py backup_db` locally and confirm a `.json` file is created in `~/backups/`
- [ ] Confirm JSON is valid: `python -m json.tool ~/backups/backup_*.json > /dev/null`
- [ ] Run with `--output-dir /tmp/test-backups` and confirm output lands in the specified directory
- [ ] Run 8+ times and confirm only 7 backups are kept
- [ ] On PythonAnywhere, schedule and confirm backup is written after task runs
- [ ] Restore from backup: `python manage.py flush --no-input && python manage.py loaddata ~/backups/backup_*.json` and confirm the site loads correctly

Closes #268