### PR TITLE
production deploy

### DIFF
--- a/blowcomotion/chart_api.py
+++ b/blowcomotion/chart_api.py
@@ -114,10 +114,10 @@ def songs_for_instrument(request, instrument_id):
             charts_data.append({
                 'id': chart.id,
                 'part': part_name,
-                'pdf_url': (chart.pdf.url if chart.pdf else None) or chart.drive_pdf_url,
+                'pdf_url': chart.drive_pdf_url or (chart.pdf.url if chart.pdf else None),
                 'pdf_title': chart.pdf.title if chart.pdf else None,
             })
-        
+
         song_data = {
             'id': song.id,
             'title': song.title,
@@ -202,9 +202,10 @@ def instruments_for_song(request, song_id):
         return JsonResponse({'error': 'Song not found'}, status=404)
     
     # Get instruments that have charts with PDFs for this song
+    has_pdf = Q(pdf__isnull=False) | Q(drive_pdf_url__isnull=False)
     instrument_ids = Chart.objects.filter(
+        has_pdf,
         song=song,
-        pdf__isnull=False
     ).values_list('instrument_id', flat=True).distinct()
     
     instruments = Instrument.objects.filter(
@@ -226,18 +227,18 @@ def instruments_for_song(request, song_id):
         
         # Get charts for this instrument and song
         charts = Chart.objects.filter(
+            has_pdf,
             song=song,
             instrument=instrument,
-            pdf__isnull=False
         ).select_related('pdf').order_by('part')
-        
+
         charts_data = []
         for chart in charts:
             part_name = chart.part if chart.part else instrument.name
             charts_data.append({
                 'id': chart.id,
                 'part': part_name,
-                'pdf_url': (chart.pdf.url if chart.pdf else None) or chart.drive_pdf_url,
+                'pdf_url': chart.drive_pdf_url or (chart.pdf.url if chart.pdf else None),
                 'pdf_title': chart.pdf.title if chart.pdf else None,
             })
         
@@ -274,19 +275,20 @@ def charts_for_song_instrument(request, song_id, instrument_id):
     except Instrument.DoesNotExist:
         return JsonResponse({'error': 'Instrument not found'}, status=404)
     
+    has_pdf = Q(pdf__isnull=False) | Q(drive_pdf_url__isnull=False)
     charts = Chart.objects.filter(
+        has_pdf,
         song=song,
         instrument=instrument,
-        pdf__isnull=False
     ).select_related('pdf').order_by('part')
-    
+
     charts_data = []
     for chart in charts:
         part_name = chart.part if chart.part else instrument.name
         charts_data.append({
             'id': chart.id,
             'part': part_name,
-            'pdf_url': (chart.pdf.url if chart.pdf else None) or chart.drive_pdf_url,
+            'pdf_url': chart.drive_pdf_url or (chart.pdf.url if chart.pdf else None),
             'pdf_title': chart.pdf.title if chart.pdf else None,
         })
 

--- a/blowcomotion/drive_sync.py
+++ b/blowcomotion/drive_sync.py
@@ -428,12 +428,3 @@ def reconcile_file(drive_file: dict, parsed: ParsedFile, existing_charts: list) 
         return ReconcileResult(drive_file, parsed, "review", "Needs review", None)
 
     return ReconcileResult(drive_file, parsed, "review", "New", None)
-
-
-def _safe_delete_document(doc):
-    from blowcomotion.models import Chart
-
-    # ponytail: skip rich-text usage scan — Chart PDFs are never embedded in rich text
-    if not Chart.objects.filter(pdf=doc).exists():
-        doc.file.delete(save=False)
-        doc.delete()

--- a/blowcomotion/tests/test_chart_api.py
+++ b/blowcomotion/tests/test_chart_api.py
@@ -341,14 +341,55 @@ class InstrumentsForSongEndpointTests(TestCase):
             title="Empty Song",
             active=True
         )
-        
+
         response = self.client.get(
             reverse('chart-instruments', kwargs={'song_id': empty_song.id})
         )
         self.assertEqual(response.status_code, 200)
-        
+
         data = response.json()
         self.assertEqual(len(data['sections']), 0)
+
+    def test_instruments_include_drive_pdf_url_only_chart(self):
+        """Test that instruments with only a Drive URL (no PDF) are included"""
+        Chart.objects.create(
+            song=self.song,
+            instrument=self.saxophone,
+            pdf=None,
+            drive_pdf_url="https://drive.google.com/file/d/f1/view",
+            part="Saxophone"
+        )
+
+        response = self.client.get(
+            reverse('chart-instruments', kwargs={'song_id': self.song.id})
+        )
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        all_instruments = []
+        for section in data['sections']:
+            all_instruments.extend([i['name'] for i in section['instruments']])
+        self.assertIn('Saxophone', all_instruments)
+
+    def test_instruments_pdf_url_prioritizes_drive_url(self):
+        """Test that pdf_url prefers drive_pdf_url over an uploaded pdf"""
+        chart = Chart.objects.get(song=self.song, instrument=self.clarinet)
+        chart.drive_pdf_url = "https://drive.google.com/file/d/f1/view"
+        chart.save()
+
+        response = self.client.get(
+            reverse('chart-instruments', kwargs={'song_id': self.song.id})
+        )
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        brass_or_woodwinds = next(
+            s for s in data['sections'] if s['name'] == 'Woodwinds'
+        )
+        clarinet = next(
+            i for i in brass_or_woodwinds['instruments'] if i['name'] == 'Clarinet'
+        )
+        self.assertEqual(clarinet['charts'][0]['pdf_url'], chart.drive_pdf_url)
 
 
 class ChartsForSongInstrumentEndpointTests(TestCase):
@@ -580,11 +621,51 @@ class ChartsForSongInstrumentEndpointTests(TestCase):
             })
         )
         self.assertEqual(response.status_code, 200)
-        
+
         data = response.json()
         # One of the charts should have part name equal to instrument name
         part_names = [c['part'] for c in data['charts']]
         self.assertIn('Test Instrument', part_names)
+
+    def test_charts_include_drive_pdf_url_only_chart(self):
+        """Test that a chart with only a Drive URL (no PDF) is returned"""
+        Chart.objects.create(
+            song=self.song,
+            instrument=self.instrument,
+            pdf=None,
+            drive_pdf_url="https://drive.google.com/file/d/f1/view",
+            part="3rd Part"
+        )
+
+        response = self.client.get(
+            reverse('chart-parts', kwargs={
+                'song_id': self.song.id,
+                'instrument_id': self.instrument.id
+            })
+        )
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        self.assertEqual(len(data['charts']), 3)
+        drive_chart = next(c for c in data['charts'] if c['part'] == '3rd Part')
+        self.assertEqual(drive_chart['pdf_url'], "https://drive.google.com/file/d/f1/view")
+
+    def test_charts_pdf_url_prioritizes_drive_url(self):
+        """Test that pdf_url prefers drive_pdf_url over an uploaded pdf"""
+        self.chart1.drive_pdf_url = "https://drive.google.com/file/d/f1/view"
+        self.chart1.save()
+
+        response = self.client.get(
+            reverse('chart-parts', kwargs={
+                'song_id': self.song.id,
+                'instrument_id': self.instrument.id
+            })
+        )
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        chart = next(c for c in data['charts'] if c['part'] == '1st Part')
+        self.assertEqual(chart['pdf_url'], self.chart1.drive_pdf_url)
 
 
 class InstrumentsWithChartsEndpointTests(TestCase):
@@ -1088,5 +1169,40 @@ class SongsForInstrumentEndpointTests(TestCase):
         # 5. Prefetch charts
         # Should NOT have one query per song for charts
         query_count = len(queries)
-        self.assertLessEqual(query_count, 6, 
+        self.assertLessEqual(query_count, 6,
             f"Expected ≤6 queries, got {query_count}. Possible N+1 query issue.")
+
+    def test_songs_include_drive_pdf_url_only_chart(self):
+        """Test that a song with only a Drive URL chart (no PDF) is included"""
+        drive_only_song = Song.objects.create(title="Drive Only Song", active=True)
+        Chart.objects.create(
+            song=drive_only_song,
+            instrument=self.clarinet,
+            pdf=None,
+            drive_pdf_url="https://drive.google.com/file/d/f1/view",
+            part="Clarinet"
+        )
+
+        response = self.client.get(
+            reverse('chart-songs-for-instrument', kwargs={'instrument_id': self.clarinet.id})
+        )
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        song_titles = [s['title'] for s in data['songs']]
+        self.assertIn('Drive Only Song', song_titles)
+
+    def test_songs_pdf_url_prioritizes_drive_url(self):
+        """Test that pdf_url prefers drive_pdf_url over an uploaded pdf"""
+        chart = Chart.objects.get(song=self.song1, instrument=self.clarinet)
+        chart.drive_pdf_url = "https://drive.google.com/file/d/f1/view"
+        chart.save()
+
+        response = self.client.get(
+            reverse('chart-songs-for-instrument', kwargs={'instrument_id': self.clarinet.id})
+        )
+        self.assertEqual(response.status_code, 200)
+
+        data = response.json()
+        song = next(s for s in data['songs'] if s['title'] == 'Test Song 1')
+        self.assertEqual(song['charts'][0]['pdf_url'], chart.drive_pdf_url)

--- a/blowcomotion/tests/test_chart_model.py
+++ b/blowcomotion/tests/test_chart_model.py
@@ -1,0 +1,40 @@
+"""
+Unit tests for the Chart model's clean() validator.
+"""
+
+from wagtail.documents.models import Document
+
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from blowcomotion.models import Chart, Instrument, Song
+
+
+class ChartCleanValidationTests(TestCase):
+    def setUp(self):
+        self.song = Song.objects.create(title="Test Song")
+        self.instrument = Instrument.objects.create(name="Trumpet")
+        self.pdf = Document.objects.create(title="Test Chart", file="test.pdf")
+
+    def _chart(self, **kwargs):
+        return Chart(song=self.song, instrument=self.instrument, **kwargs)
+
+    def test_clean_raises_when_neither_pdf_nor_url(self):
+        chart = self._chart()
+        with self.assertRaises(ValidationError):
+            chart.clean()
+
+    def test_clean_passes_with_pdf_only(self):
+        chart = self._chart(pdf=self.pdf)
+        chart.clean()
+
+    def test_clean_passes_with_drive_pdf_url_only(self):
+        chart = self._chart(drive_pdf_url="https://drive.google.com/file/d/f1/view")
+        chart.clean()
+
+    def test_clean_passes_with_both_pdf_and_drive_pdf_url(self):
+        chart = self._chart(
+            pdf=self.pdf,
+            drive_pdf_url="https://drive.google.com/file/d/f1/view",
+        )
+        chart.clean()


### PR DESCRIPTION
## Summary
- Deploy `development` to `main`.
- Includes: prioritize Drive URL over PDF in chart library, fix `instruments_for_song`/`charts_for_song_instrument` to include Drive-URL-only charts, remove dead `_safe_delete_document` in `drive_sync.py`, and add regression tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_014Uu7Awid2KsjbFpfkTmjxE)_