### PR TITLE
feat: add delete button on denied rental-requests admin page

### DIFF
--- a/blowcomotion/templates/wagtailadmin/rental_requests_dashboard.html
+++ b/blowcomotion/templates/wagtailadmin/rental_requests_dashboard.html
@@ -87,6 +87,15 @@
                     </form>
                     {% endif %}
                     {% endif %}
+                    {% if sub.status == 'denied' %}
+                    <form method="post" style="display:inline;"
+                          onsubmit="return confirm('Delete this denied rental request from {{ sub.name|escapejs }}? This cannot be undone.');">
+                        {% csrf_token %}
+                        <input type="hidden" name="action" value="delete">
+                        <input type="hidden" name="pk" value="{{ sub.pk }}">
+                        <button type="submit" class="button button-small no">Delete</button>
+                    </form>
+                    {% endif %}
                 </td>
             </tr>
             {% empty %}

--- a/blowcomotion/tests/test_instrument_rental.py
+++ b/blowcomotion/tests/test_instrument_rental.py
@@ -648,6 +648,43 @@ class RentalRequestsAdminViewTest(TestCase):
         self.assertTrue(any("Summary" in s for s in subjects))
         self.assertTrue(any("[COPY]" in s for s in subjects))
 
+    def test_delete_removes_denied_submission(self):
+        self.submission.status = InstrumentRentalRequestSubmission.STATUS_DENIED
+        self.submission.save()
+        pk = self.submission.pk
+        self.client.post(
+            reverse("rental_requests_dashboard"),
+            {"action": "delete", "pk": pk},
+        )
+        self.assertFalse(
+            InstrumentRentalRequestSubmission.objects.filter(pk=pk).exists()
+        )
+
+    def test_delete_on_non_denied_submission_returns_404(self):
+        self.submission.status = InstrumentRentalRequestSubmission.STATUS_PENDING
+        self.submission.save()
+        pk = self.submission.pk
+        response = self.client.post(
+            reverse("rental_requests_dashboard"),
+            {"action": "delete", "pk": pk},
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertTrue(
+            InstrumentRentalRequestSubmission.objects.filter(pk=pk).exists()
+        )
+
+    def test_delete_on_approved_submission_returns_404(self):
+        self._make_approved_submission()
+        pk = self.submission.pk
+        response = self.client.post(
+            reverse("rental_requests_dashboard"),
+            {"action": "delete", "pk": pk},
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertTrue(
+            InstrumentRentalRequestSubmission.objects.filter(pk=pk).exists()
+        )
+
 
 class PatreonClientTest(TestCase):
     """Unit tests for check_patreon_membership() in patreon_client.py.

--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -2693,6 +2693,18 @@ def rental_requests_dashboard(request):
                 messages.info(request, f"Nag all: nothing to send ({skipped_cooldown} skipped by cooldown).")
             return redirect("rental_requests_dashboard")
 
+        elif action == "delete":
+            pk = request.POST.get("pk")
+            sub = get_object_or_404(
+                InstrumentRentalRequestSubmission,
+                pk=pk,
+                status=InstrumentRentalRequestSubmission.STATUS_DENIED,
+            )
+            name = sub.name
+            sub.delete()
+            messages.success(request, f"Deleted denied rental request from {name}.")
+            return redirect("rental_requests_dashboard")
+
     submissions = list(
         InstrumentRentalRequestSubmission.objects.annotate(
             status_order=Case(


### PR DESCRIPTION
Closes #286

## Summary
- Add a `delete` POST action to the rental requests admin dashboard, following the same pattern as the existing `nag_one`/`nag_all` actions.
- The delete action is gated server-side via `get_object_or_404(InstrumentRentalRequestSubmission, pk=pk, status=STATUS_DENIED)` — only submissions currently in the `denied` state can be deleted; any other status 404s.
- The Delete button only renders in the template for rows with `status == 'denied'`, uses Wagtail's built-in destructive-button styling, and prompts for confirmation before submitting.
- Auth follows the existing dashboard pattern: the view is registered via Wagtail's `register_admin_urls` hook, so access requires being logged into Wagtail admin (no separate decorator needed, matching `nag_one`/`nag_all`/`refresh_patreon`).

## Test plan
- [x] `python manage.py test blowcomotion.tests.test_instrument_rental.RentalRequestsAdminViewTest` — 21/21 pass, including 3 new tests covering: delete removes a denied submission; delete on a pending submission 404s and does not delete; delete on an approved submission 404s and does not delete.
- [x] Full test suite (`python manage.py test`) — 577/577 pass.
- [x] `isort --check-only blowcomotion/ --diff` — clean.