### PR TITLE
feat: add confirm step to nag-all showing who will be nagged and with what

### DIFF
--- a/blowcomotion/templates/wagtailadmin/rental_requests_dashboard.html
+++ b/blowcomotion/templates/wagtailadmin/rental_requests_dashboard.html
@@ -29,7 +29,7 @@
                     <th>Member</th>
                     <th>Instrument</th>
                     <th>Reason</th>
-                    <th>CTA link in email</th>
+                    <th>Message they'll be asked to confirm</th>
                     <th>Will send?</th>
                 </tr>
             </thead>
@@ -57,7 +57,7 @@
                 {% endfor %}
             </tbody>
         </table>
-        <p><small><strong>Reason</strong> key: <strong>attendance</strong> = no recent rehearsal attendance; <strong>patreon</strong> = Patreon status not confirmed active. <strong>CTA link in email</strong> shows the confirmation button the renter is asked to click in the email they'll receive.</small></p>
+        <p><small><strong>Reason</strong> key: <strong>attendance</strong> = no recent rehearsal attendance; <strong>patreon</strong> = Patreon status not confirmed active. <strong>Message they'll be asked to confirm</strong> is the confirmation link's label in the email they'll receive.</small></p>
     </details>
     {% endif %}
     <script>

--- a/blowcomotion/templates/wagtailadmin/rental_requests_dashboard.html
+++ b/blowcomotion/templates/wagtailadmin/rental_requests_dashboard.html
@@ -12,12 +12,57 @@
             <input type="hidden" name="action" value="refresh_patreon">
             <button type="submit" class="button button-secondary">Refresh Patreon status</button>
         </form>
-        <form method="post" style="display:inline;">
+        <form method="post" style="display:inline;" onsubmit="return confirm(nagAllConfirmMessage);">
             {% csrf_token %}
             <input type="hidden" name="action" value="nag_all">
             <button type="submit" class="button button-secondary">Nag all eligible renters</button>
         </form>
     </div>
+    {% if nag_all_preview %}
+    <details style="margin-bottom:1rem;">
+        <summary style="cursor:pointer;color:var(--w-color-text-link-default);text-decoration:underline;font-weight:bold;">
+            Preview: who "Nag all eligible renters" will email ({{ nag_all_preview|length }}) — click to expand/collapse
+        </summary>
+        <table class="listing">
+            <thead>
+                <tr>
+                    <th>Member</th>
+                    <th>Instrument</th>
+                    <th>Reason</th>
+                    <th>CTA link in email</th>
+                    <th>Will send?</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for item in nag_all_preview %}
+                <tr>
+                    <td>{{ item.member.full_name }}<br><small>{{ item.member.email }}</small></td>
+                    <td>{{ item.instrument.instrument.name }}</td>
+                    <td>{{ item.reasons|join:" + " }}</td>
+                    <td>
+                        {% if item.cta == "staying" %}
+                        "I'll be back at rehearsal soon"
+                        {% else %}
+                        "I've updated my Patreon membership"
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if item.in_cooldown %}
+                        <span style="color:#666;" title="Nagged within the cooldown period">Skipped — in cooldown</span>
+                        {% else %}
+                        <span style="color:green;">Yes</span>
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        <p><small><strong>Reason</strong> key: <strong>attendance</strong> = no recent rehearsal attendance; <strong>patreon</strong> = Patreon status not confirmed active. <strong>CTA link in email</strong> shows the confirmation button the renter is asked to click in the email they'll receive.</small></p>
+    </details>
+    {% endif %}
+    <script>
+        var nagAllConfirmMessage = "{{ nag_all_confirm_message|escapejs }}";
+    </script>
     {% if messages %}
     {% for message in messages %}
     <p class="help-block help-block-{{ message.tags }}">{{ message }}</p>

--- a/blowcomotion/tests/test_instrument_rental.py
+++ b/blowcomotion/tests/test_instrument_rental.py
@@ -648,6 +648,75 @@ class RentalRequestsAdminViewTest(TestCase):
         self.assertTrue(any("Summary" in s for s in subjects))
         self.assertTrue(any("[COPY]" in s for s in subjects))
 
+    def test_nag_all_preview_lists_eligible_renter_with_reason(self):
+        self.li.status = LibraryInstrument.STATUS_RENTED
+        self.li.member = self.member
+        self.li.save()
+        response = self.client.get(reverse("rental_requests_dashboard"))
+        preview = response.context["nag_all_preview"]
+        self.assertEqual(len(preview), 1)
+        self.assertEqual(preview[0]["member"], self.member)
+        self.assertIn("attendance", preview[0]["reasons"])
+        self.assertFalse(preview[0]["in_cooldown"])
+        self.assertIn(self.member.full_name, response.context["nag_all_confirm_message"])
+
+    def test_nag_all_preview_matches_who_nag_all_actually_emails(self):
+        # The preview (GET) and the real send (POST) must derive from the same
+        # eligibility computation, or the confirm step could show a different
+        # set of renters than actually get nagged. Includes a cooldown renter
+        # so the full preview list and the sendable (non-cooldown) subset can
+        # be told apart — comparing the full preview to sent mail would pass
+        # even if cooldown-skipped renters leaked into the confirm text.
+        import datetime
+        other_instrument = make_instrument("Trombone")
+        other_li = make_library_instrument(other_instrument, serial="SN002")
+        other_member = make_member(email="other@example.com", first_name="Robin", last_name="Brass")
+
+        self.li.status = LibraryInstrument.STATUS_RENTED
+        self.li.member = self.member
+        self.li.save()
+
+        other_li.status = LibraryInstrument.STATUS_RENTED
+        other_li.member = other_member
+        other_li.last_nag_sent = datetime.date.today()
+        other_li.save()
+
+        response = self.client.get(reverse("rental_requests_dashboard"))
+        preview = response.context["nag_all_preview"]
+        confirm_message = response.context["nag_all_confirm_message"]
+        preview_emails = {item["member"].email for item in preview}
+        sendable_emails = {item["member"].email for item in preview if not item["in_cooldown"]}
+
+        # Both renters are eligible, so both appear in the full preview...
+        self.assertEqual(preview_emails, {self.member.email, other_member.email})
+        # ...but only the non-cooldown renter is sendable, and only they're
+        # named in the confirm text.
+        self.assertEqual(sendable_emails, {self.member.email})
+        self.assertIn(self.member.full_name, confirm_message)
+        self.assertNotIn(other_member.full_name, confirm_message)
+
+        self.client.post(reverse("rental_requests_dashboard"), {"action": "nag_all"})
+        sent_emails = {addr for m in mail.outbox for addr in m.to}
+
+        self.assertEqual(sendable_emails, sent_emails)
+
+    def test_nag_all_preview_marks_cooldown_renter_but_excludes_from_confirm_text(self):
+        import datetime
+        self.li.status = LibraryInstrument.STATUS_RENTED
+        self.li.member = self.member
+        self.li.last_nag_sent = datetime.date.today()
+        self.li.save()
+        response = self.client.get(reverse("rental_requests_dashboard"))
+        preview = response.context["nag_all_preview"]
+        self.assertEqual(len(preview), 1)
+        self.assertTrue(preview[0]["in_cooldown"])
+        self.assertNotIn(self.member.full_name, response.context["nag_all_confirm_message"])
+
+    def test_nag_all_confirm_message_when_none_eligible(self):
+        response = self.client.get(reverse("rental_requests_dashboard"))
+        self.assertEqual(response.context["nag_all_preview"], [])
+        self.assertIn("No renters are currently eligible", response.context["nag_all_confirm_message"])
+
     def test_delete_removes_denied_submission(self):
         self.submission.status = InstrumentRentalRequestSubmission.STATUS_DENIED
         self.submission.save()

--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -2616,24 +2616,15 @@ def rental_requests_dashboard(request):
             return redirect("rental_requests_dashboard")
 
         elif action == "nag_all":
-            instruments = LibraryInstrument.objects.filter(
-                status=LibraryInstrument.STATUS_RENTED,
-                member__isnull=False,
-                member__email__isnull=False,
-            ).exclude(member__email="").select_related("member", "instrument")
+            candidates = _get_nag_all_candidates(cutoff)
 
             nagged = []
             failed = []
             skipped_cooldown = 0
-            for li in instruments:
-                member = li.member
-                reasons = []
-                if not member.is_active or not member.last_seen or member.last_seen < cutoff:
-                    reasons.append("attendance")
-                if not li.patreon_active:
-                    reasons.append("patreon")
-                if not reasons:
-                    continue
+            for candidate in candidates:
+                li = candidate["instrument"]
+                member = candidate["member"]
+                reasons = candidate["reasons"]
 
                 # Atomic cooldown gate — prevents double-send on concurrent clicks
                 claimed = LibraryInstrument.objects.filter(pk=li.pk).filter(
@@ -2734,8 +2725,34 @@ def rental_requests_dashboard(request):
                 or sub.patreon_validated is not True
             )
         sub.nag_eligible = nag_eligible
+
+    nag_all_preview = []
+    sendable_lines = []
+    for candidate in _get_nag_all_candidates(cutoff):
+        li = candidate["instrument"]
+        in_cooldown = bool(li.last_nag_sent and (today - li.last_nag_sent).days < cooldown_days)
+        reason_label = " + ".join(candidate["reasons"])
+        nag_all_preview.append({
+            "member": candidate["member"],
+            "instrument": li,
+            "reasons": candidate["reasons"],
+            "cta": _nag_cta_for_reasons(candidate["reasons"]),
+            "in_cooldown": in_cooldown,
+        })
+        if not in_cooldown:
+            sendable_lines.append(f"{candidate['member'].full_name} ({li.instrument.name}) — {reason_label}")
+
+    if sendable_lines:
+        nag_all_confirm_message = "Send nag emails to the following renters?\n\n" + "\n".join(sendable_lines)
+    elif nag_all_preview:
+        nag_all_confirm_message = "No emails will be sent — all eligible renters are currently in cooldown."
+    else:
+        nag_all_confirm_message = "No renters are currently eligible for a nag email."
+
     return render(request, "wagtailadmin/rental_requests_dashboard.html", {
         "submissions": submissions,
+        "nag_all_preview": nag_all_preview,
+        "nag_all_confirm_message": nag_all_confirm_message,
     })
 
 
@@ -2854,6 +2871,48 @@ def _get_site_settings_for_view():
     return SiteSettings.for_site(site)
 
 
+def _get_nag_all_candidates(cutoff):
+    """Return the list of renters that 'Nag all eligible renters' would email right now.
+
+    Read-only — does not touch cooldown state or send anything. Used both to build the
+    confirmation preview shown before the bulk nag runs and, as the source of truth for
+    eligibility/reasons, by the nag_all POST handler itself, so the preview can never
+    drift from what actually gets sent.
+
+    Each item: {"instrument": LibraryInstrument, "member": Member, "reasons": [...]}.
+    "reasons" may include "attendance" and/or "patreon"; see _build_nag_email for how
+    reasons map to the CTA included in the email.
+    """
+    instruments = LibraryInstrument.objects.filter(
+        status=LibraryInstrument.STATUS_RENTED,
+        member__isnull=False,
+        member__email__isnull=False,
+    ).exclude(member__email="").select_related("member", "instrument")
+
+    candidates = []
+    for li in instruments:
+        member = li.member
+        reasons = []
+        if not member.is_active or not member.last_seen or member.last_seen < cutoff:
+            reasons.append("attendance")
+        if not li.patreon_active:
+            reasons.append("patreon")
+        if not reasons:
+            continue
+        candidates.append({"instrument": li, "member": member, "reasons": reasons})
+    return candidates
+
+
+def _nag_cta_for_reasons(reasons):
+    """Return the nag email's call-to-action slug ('staying' or 'patreon-updated') for reasons.
+
+    Single source of truth for the reason->CTA mapping, shared by _build_nag_email (which
+    builds the actual confirm link) and the nag-all preview (which just labels it) so the
+    two can't drift apart.
+    """
+    return "staying" if "attendance" in reasons else "patreon-updated"
+
+
 def _build_nag_email(li, member, base_url, patreon_url, reasons):
     """Build (subject, message) for a rental nag email. reasons is a list of 'attendance'/'patreon'."""
     from django.core.signing import TimestampSigner
@@ -2876,12 +2935,12 @@ def _build_nag_email(li, member, base_url, patreon_url, reasons):
         if patreon_url:
             patreon_line += f" You can activate or renew at: {patreon_url}"
         lines += [patreon_line, ""]
-    if "attendance" in reasons:
+    cta = _nag_cta_for_reasons(reasons)
+    if cta == "staying":
         confirm_label = "I'll be back at rehearsal soon:"
-        confirm_url = f"{base_url}/instrument-rental/staying/?t={token}"
     else:
         confirm_label = "I've updated my Patreon membership:"
-        confirm_url = f"{base_url}/instrument-rental/patreon-updated/?t={token}"
+    confirm_url = f"{base_url}/instrument-rental/{cta}/?t={token}"
     lines += [
         "Please let us know your plans:",
         "",


### PR DESCRIPTION
Closes #289

## Summary
- Adds a collapsible preview panel above the "Nag all eligible renters" button on the rental requests admin dashboard, listing every renter who is currently eligible for a nag email, their reason(s) (attendance / patreon), the confirmation message they'll be asked to click in their email, and whether they'll actually be sent one (renters in the nag cooldown are shown but marked skipped).
- The button's form now uses `onsubmit="return confirm(...)"` (same pattern as the existing "Delete" button) with a dynamically built message listing exactly who will be emailed and why, so admins get a real preview before triggering the bulk send.
- Extracted `_get_nag_all_candidates()` as the single source of truth for nag-all eligibility, used by both the POST handler (which still does its own atomic per-candidate cooldown claim before sending) and the GET path that builds the preview/confirm text — this ensures the confirmation can never show a different set of people than actually get nagged.
- Extracted `_nag_cta_for_reasons()` so the preview's message label and the actual email's confirmation link share one reason-to-CTA mapping, preventing that from drifting either.
- No changes to who gets nagged or what content is sent — this is purely a confirmation/preview step in front of the existing `nag_all` action.

## Test plan
- [x] `python manage.py test blowcomotion.tests.test_instrument_rental` — 85 tests pass, including 4 new tests covering: preview lists an eligible renter with correct reasons, the preview/confirm-text sendable subset matches exactly who `nag_all` actually emails (with a cooldown renter included to prove drift can't happen), cooldown renters are shown in the preview but excluded from the confirm text, and the "none eligible" / "all in cooldown" message wording.
- [x] Full test suite (`python manage.py test`) — 581 tests pass.
- [x] Manually verified in a local dev server: seeded two approved rentals (one eligible+sendable, one eligible+in-cooldown) and confirmed the preview table and confirm dialog correctly separate the two.
- [ ] Reviewer: expand the preview panel on `/admin/rental-requests/` and click "Nag all eligible renters" to see the confirm dialog listing renters and reasons.