### PR TITLE
feat: add attendance record and stats to member portal

### DIFF
--- a/blowcomotion/member_urls.py
+++ b/blowcomotion/member_urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
     # Portal views (added in Task 9)
     path("confirm-email/<uuid:token_uuid>/", member_views.confirm_email_view, name="member-confirm-email"),
     path("profile/", member_views.profile_view, name="member-profile"),
+    path("attendance/", member_views.attendance_view, name="member-attendance"),
     path("requests/", member_views.requests_view, name="member-requests"),
     path("requests/<int:pk>/", member_views.rental_request_detail, name="member-rental-request-detail"),
     path("instrument-rental/", member_views.instrument_rental_request, name="member-instrument-rental"),

--- a/blowcomotion/member_views.py
+++ b/blowcomotion/member_views.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import timedelta
+from datetime import date, timedelta
 
 from django_ratelimit.decorators import ratelimit
 
@@ -8,7 +8,9 @@ from django.contrib import messages
 from django.contrib.auth import get_user_model, login, views as auth_views
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import PasswordResetForm, SetPasswordForm
+from django.core.paginator import Paginator
 from django.db import transaction
+from django.db.models import Count
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.utils import timezone
@@ -225,6 +227,10 @@ def profile_view(request):
             "shirt_size_choices": SHIRT_SIZE_CHOICES,
             "dietary_choices": DIETARY_CHOICES,
             "allergen_choices": ALLERGEN_CHOICES,
+            "attendance_total": member.attendance_records.count(),
+            "attendance_this_year": member.attendance_records.filter(
+                date__year=date.today().year
+            ).count(),
         }
 
     if request.method == "POST":
@@ -299,6 +305,115 @@ def requests_view(request):
     member = request.user.member
     rental_requests = member.rental_requests.select_related("instrument")
     return render(request, "member/requests.html", {"member": member, "rental_requests": rental_requests})
+
+
+ATTENDANCE_RATE_WEEKS = 12
+ATTENDANCE_PAGE_SIZE = 50
+
+
+def _count_tuesdays(start_date, end_date):
+    """Count practice Tuesdays between two dates, inclusive."""
+    count = 0
+    current = start_date
+    while current <= end_date:
+        if current.weekday() == 1:  # Tuesday
+            count += 1
+        current += timedelta(days=1)
+    return count
+
+
+def _attendance_streaks(record_dates, today):
+    """
+    Compute (current_streak, longest_streak) in weeks. A week counts toward a
+    streak if it has at least one attendance record; the current streak may
+    anchor on this week or last week, since this week's practice may not have
+    happened yet.
+    """
+    if not record_dates:
+        return 0, 0
+
+    def week_index(d):
+        iso = d.isocalendar()
+        # Ordinal of the ISO week's Monday // 7 gives a consecutive week number
+        return date.fromisocalendar(iso[0], iso[1], 1).toordinal() // 7
+
+    weeks = sorted({week_index(d) for d in record_dates})
+    week_set = set(weeks)
+
+    longest = run = 1
+    for prev, cur in zip(weeks, weeks[1:]):
+        run = run + 1 if cur == prev + 1 else 1
+        longest = max(longest, run)
+
+    this_week = week_index(today)
+    if this_week in week_set:
+        anchor = this_week
+    elif this_week - 1 in week_set:
+        anchor = this_week - 1
+    else:
+        return 0, longest
+
+    current = 0
+    while anchor in week_set:
+        current += 1
+        anchor -= 1
+    return current, longest
+
+
+@login_required
+@require_GET
+def attendance_view(request):
+    if not hasattr(request.user, "member"):
+        return redirect("/")
+    member = request.user.member
+    records = member.attendance_records.select_related("played_instrument").order_by("-date")
+
+    today = date.today()
+    stats = None
+    record_dates = list(records.values_list("date", flat=True))
+    if record_dates:
+        window_start = today - timedelta(weeks=ATTENDANCE_RATE_WEEKS)
+        window_count = sum(1 for d in record_dates if d >= window_start)
+        effective_start = (
+            max(window_start, member.join_date) if member.join_date else window_start
+        )
+        window_tuesdays = _count_tuesdays(effective_start, today)
+        rate = (
+            min(100, round(window_count / window_tuesdays * 100))
+            if window_tuesdays
+            else None
+        )
+
+        current_streak, longest_streak = _attendance_streaks(record_dates, today)
+
+        stats = {
+            "total": len(record_dates),
+            "this_year": sum(1 for d in record_dates if d.year == today.year),
+            "first_date": record_dates[-1],
+            "last_date": record_dates[0],
+            "window_count": window_count,
+            "window_tuesdays": window_tuesdays,
+            "window_weeks": ATTENDANCE_RATE_WEEKS,
+            "rate": rate,
+            "current_streak": current_streak,
+            "longest_streak": longest_streak,
+            "by_year": records.values("date__year")
+            .annotate(count=Count("id"))
+            .order_by("-date__year"),
+            "instruments": records.filter(played_instrument__isnull=False)
+            .values("played_instrument__name")
+            .annotate(count=Count("id"))
+            .order_by("-count", "played_instrument__name"),
+        }
+
+    paginator = Paginator(records, ATTENDANCE_PAGE_SIZE)
+    page_obj = paginator.get_page(request.GET.get("page"))
+
+    return render(request, "member/attendance.html", {
+        "member": member,
+        "stats": stats,
+        "page_obj": page_obj,
+    })
 
 
 @login_required

--- a/blowcomotion/templates/member/attendance.html
+++ b/blowcomotion/templates/member/attendance.html
@@ -1,0 +1,129 @@
+{% extends "member/portal_base.html" %}
+{% block title %}My Attendance — Blowcomotion{% endblock %}
+{% block portal_content %}
+<h2 class="mb-4">My Attendance</h2>
+
+{% if stats %}
+<div class="row g-3 mb-4">
+    <div class="col-md-6">
+        <div class="card h-100">
+            <div class="card-header">Summary</div>
+            <div class="card-body p-0">
+                <table class="table mb-0">
+                    <tbody>
+                        <tr>
+                            <th scope="row">Total events attended</th>
+                            <td>{{ stats.total }}</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">This year</th>
+                            <td>{{ stats.this_year }}</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Last {{ stats.window_weeks }} weeks</th>
+                            <td>
+                                {{ stats.window_count }} of {{ stats.window_tuesdays }} practice Tuesday{{ stats.window_tuesdays|pluralize }}
+                                {% if stats.rate is not None %}({{ stats.rate }}%){% endif %}
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Current streak</th>
+                            <td>{{ stats.current_streak }} week{{ stats.current_streak|pluralize }}</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Longest streak</th>
+                            <td>{{ stats.longest_streak }} week{{ stats.longest_streak|pluralize }}</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">First recorded</th>
+                            <td>{{ stats.first_date|date:"N j, Y" }}</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Most recent</th>
+                            <td>{{ stats.last_date|date:"N j, Y" }}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="card mb-3">
+            <div class="card-header">By Year</div>
+            <div class="card-body p-0">
+                <table class="table mb-0">
+                    <tbody>
+                    {% for row in stats.by_year %}
+                        <tr>
+                            <th scope="row">{{ row.date__year }}</th>
+                            <td>{{ row.count }} event{{ row.count|pluralize }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {% if stats.instruments %}
+        <div class="card">
+            <div class="card-header">Instruments Played</div>
+            <div class="card-body p-0">
+                <table class="table mb-0">
+                    <tbody>
+                    {% for row in stats.instruments %}
+                        <tr>
+                            <th scope="row">{{ row.played_instrument__name }}</th>
+                            <td>{{ row.count }} time{{ row.count|pluralize }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {% endif %}
+    </div>
+</div>
+
+<h4 class="mb-3">Attendance History</h4>
+<div class="table-responsive">
+    <table class="table table-hover align-middle">
+        <thead class="table-light">
+            <tr>
+                <th>Date</th>
+                <th>Event</th>
+                <th>Instrument</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for record in page_obj %}
+            <tr>
+                <td>{{ record.date|date:"D, N j, Y" }}</td>
+                <td>{{ record.notes|default:"—" }}</td>
+                <td>{{ record.played_instrument.name|default:"—" }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+
+{% if page_obj.paginator.num_pages > 1 %}
+<nav aria-label="Attendance pages">
+    <ul class="pagination">
+        {% if page_obj.has_previous %}
+        <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}">Previous</a></li>
+        {% else %}
+        <li class="page-item disabled"><span class="page-link">Previous</span></li>
+        {% endif %}
+        <li class="page-item disabled"><span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span></li>
+        {% if page_obj.has_next %}
+        <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}">Next</a></li>
+        {% else %}
+        <li class="page-item disabled"><span class="page-link">Next</span></li>
+        {% endif %}
+    </ul>
+</nav>
+{% endif %}
+
+{% else %}
+<p class="text-muted">No attendance has been recorded for you yet. Once you check in at a practice or performance, your history will show up here.</p>
+{% endif %}
+{% endblock %}

--- a/blowcomotion/templates/member/portal_base.html
+++ b/blowcomotion/templates/member/portal_base.html
@@ -5,6 +5,7 @@
         <div class="col-md-3 mb-4">
             <nav class="list-group">
                 <a href="{% url 'member-profile' %}" class="list-group-item list-group-item-action{% if request.resolver_match.url_name == 'member-profile' %} active{% endif %}">My Profile</a>
+                <a href="{% url 'member-attendance' %}" class="list-group-item list-group-item-action{% if request.resolver_match.url_name == 'member-attendance' %} active{% endif %}">My Attendance</a>
                 <a href="{% url 'member-requests' %}" class="list-group-item list-group-item-action{% if request.resolver_match.url_name == 'member-requests' %} active{% endif %}">My Requests</a>
                 <a href="{% url 'member-instrument-rental' %}" class="list-group-item list-group-item-action{% if request.resolver_match.url_name == 'member-instrument-rental' %} active{% endif %}">Request an Instrument</a>
                 <form method="post" action="{% url 'member-logout' %}" style="margin:0;">

--- a/blowcomotion/templates/member/profile.html
+++ b/blowcomotion/templates/member/profile.html
@@ -10,6 +10,19 @@
     A confirmation email has been sent to <strong>{{ member.pending_email }}</strong>. Click the link in that email to complete the change.
 </div>
 {% endif %}
+<div class="card mb-4">
+    <div class="card-body d-flex justify-content-between align-items-center flex-wrap gap-2">
+        <div>
+            <strong>Attendance:</strong>
+            {% if attendance_total %}
+                {{ attendance_total }} event{{ attendance_total|pluralize }} attended ({{ attendance_this_year }} this year)
+            {% else %}
+                no attendance recorded yet
+            {% endif %}
+        </div>
+        <a href="{% url 'member-attendance' %}" class="btn btn-sm site-btn">View Attendance Record</a>
+    </div>
+</div>
 <form method="post" enctype="multipart/form-data" id="member-form">
     {% csrf_token %}
     <input type="hidden" name="g-recaptcha-response" value="">

--- a/blowcomotion/tests/test_member_attendance.py
+++ b/blowcomotion/tests/test_member_attendance.py
@@ -1,0 +1,151 @@
+from datetime import date, timedelta
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from blowcomotion.member_auth import create_member_user
+from blowcomotion.member_views import _attendance_streaks, _count_tuesdays
+from blowcomotion.models import AttendanceRecord, Instrument, Member
+
+User = get_user_model()
+
+
+def make_member(**kwargs):
+    defaults = dict(first_name="Casey", last_name="Player", email="casey@example.com")
+    defaults.update(kwargs)
+    return Member.objects.create(**defaults)
+
+
+def last_tuesday(before=None):
+    """Most recent Tuesday on or before the given date (default today)."""
+    d = before or date.today()
+    return d - timedelta(days=(d.weekday() - 1) % 7)
+
+
+class AttendanceViewAuthTests(TestCase):
+    def test_anonymous_redirects_to_login(self):
+        response = self.client.get(reverse("member-attendance"))
+        self.assertRedirects(
+            response,
+            "/member/login/?next=/member/attendance/",
+            fetch_redirect_response=False,
+        )
+
+    def test_staff_user_without_member_redirects(self):
+        User.objects.create_user(username="staff@example.com", password="StaffP@ss!")
+        self.client.login(username="staff@example.com", password="StaffP@ss!")
+        response = self.client.get(reverse("member-attendance"))
+        self.assertEqual(response.status_code, 302)
+
+    def test_post_not_allowed(self):
+        member = make_member()
+        user = create_member_user(member)
+        user.set_password("Pass123!")
+        user.save()
+        self.client.login(username="casey@example.com", password="Pass123!")
+        response = self.client.post(reverse("member-attendance"))
+        self.assertEqual(response.status_code, 405)
+
+
+class AttendanceViewTests(TestCase):
+    def setUp(self):
+        self.member = make_member(join_date=date.today() - timedelta(weeks=52))
+        self.user = create_member_user(self.member)
+        self.user.set_password("Pass123!")
+        self.user.save()
+        self.client.login(username="casey@example.com", password="Pass123!")
+
+    def test_empty_state_renders(self):
+        response = self.client.get(reverse("member-attendance"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "No attendance has been recorded")
+
+    def test_records_and_stats_render(self):
+        instrument = Instrument.objects.create(name="Trombone")
+        tuesday = last_tuesday()
+        for weeks_ago in range(3):
+            AttendanceRecord.objects.create(
+                member=self.member,
+                date=tuesday - timedelta(weeks=weeks_ago),
+                played_instrument=instrument,
+                notes="Rehearsal",
+            )
+        response = self.client.get(reverse("member-attendance"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Total events attended")
+        self.assertContains(response, "Trombone")
+        self.assertContains(response, "Rehearsal")
+        self.assertEqual(response.context["stats"]["total"], 3)
+        self.assertEqual(response.context["stats"]["current_streak"], 3)
+        self.assertEqual(response.context["stats"]["longest_streak"], 3)
+
+    def test_does_not_show_other_members_records(self):
+        other = make_member(first_name="Riley", email="riley@example.com")
+        AttendanceRecord.objects.create(member=other, date=last_tuesday())
+        response = self.client.get(reverse("member-attendance"))
+        self.assertContains(response, "No attendance has been recorded")
+
+    def test_guest_records_are_excluded(self):
+        AttendanceRecord.objects.create(guest_name="Some Guest", date=last_tuesday())
+        response = self.client.get(reverse("member-attendance"))
+        self.assertContains(response, "No attendance has been recorded")
+
+    def test_pagination(self):
+        start = last_tuesday()
+        for weeks_ago in range(60):
+            AttendanceRecord.objects.create(
+                member=self.member, date=start - timedelta(weeks=weeks_ago)
+            )
+        response = self.client.get(reverse("member-attendance"))
+        self.assertEqual(len(response.context["page_obj"]), 50)
+        response = self.client.get(reverse("member-attendance"), {"page": 2})
+        self.assertEqual(len(response.context["page_obj"]), 10)
+
+    def test_profile_page_shows_attendance_summary(self):
+        AttendanceRecord.objects.create(member=self.member, date=last_tuesday())
+        response = self.client.get(reverse("member-profile"))
+        self.assertContains(response, "View Attendance Record")
+        self.assertEqual(response.context["attendance_total"], 1)
+
+
+class AttendanceHelperTests(TestCase):
+    def test_count_tuesdays_one_week(self):
+        # Mon 2026-06-22 .. Sun 2026-06-28 contains one Tuesday (2026-06-23)
+        self.assertEqual(_count_tuesdays(date(2026, 6, 22), date(2026, 6, 28)), 1)
+
+    def test_count_tuesdays_empty_range(self):
+        self.assertEqual(_count_tuesdays(date(2026, 6, 24), date(2026, 6, 22)), 0)
+
+    def test_streaks_empty(self):
+        self.assertEqual(_attendance_streaks([], date(2026, 6, 23)), (0, 0))
+
+    def test_streaks_consecutive_weeks(self):
+        today = date(2026, 6, 25)  # Thursday
+        tuesdays = [date(2026, 6, 23), date(2026, 6, 16), date(2026, 6, 9)]
+        self.assertEqual(_attendance_streaks(tuesdays, today), (3, 3))
+
+    def test_streak_broken_by_gap(self):
+        today = date(2026, 6, 25)
+        dates = [date(2026, 6, 23), date(2026, 6, 9), date(2026, 6, 2)]
+        current, longest = _attendance_streaks(dates, today)
+        self.assertEqual(current, 1)
+        self.assertEqual(longest, 2)
+
+    def test_current_streak_zero_when_stale(self):
+        today = date(2026, 6, 25)
+        dates = [date(2026, 5, 5), date(2026, 4, 28)]
+        current, longest = _attendance_streaks(dates, today)
+        self.assertEqual(current, 0)
+        self.assertEqual(longest, 2)
+
+    def test_current_streak_anchors_on_last_week(self):
+        # No record yet this week, but last week attended
+        today = date(2026, 6, 22)  # Monday, before this week's practice
+        dates = [date(2026, 6, 16), date(2026, 6, 9)]
+        self.assertEqual(_attendance_streaks(dates, today), (2, 2))
+
+    def test_streak_across_year_boundary(self):
+        today = date(2026, 1, 8)
+        dates = [date(2026, 1, 6), date(2025, 12, 30)]
+        self.assertEqual(_attendance_streaks(dates, today), (2, 2))


### PR DESCRIPTION
Adds a "My Attendance" page to the member portal at `/member/attendance/`, linked from the portal sidebar nav and a new summary card on the profile page.

## What's included

- Paginated attendance history (50 per page) for the logged-in member: date, event (from record notes), and instrument played
- Summary stats: total events attended, this-year count, 12-week practice attendance rate (same Tuesday-counting logic as section reports, respecting join date), current and longest weekly streaks, per-year breakdown, and instruments-played tally
- Profile page summary card with a link to the full record
- View is GET-only and scoped to `request.user.member`; guest records excluded

## Testing

- 17 new tests in `test_member_attendance.py` covering auth gating, cross-member isolation, pagination, and streak/Tuesday math including year boundaries
- Full suite passes (598 tests); isort clean
- Verified in a browser against a seeded dev database

No migrations and no static file changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_0127YApTKH4n2TUjgZ8JuFP7)_