### PR TITLE
fix: keep attendance capture success confirmation visible until dismissed

### DIFF
--- a/blowcomotion/templates/attendance/partials/capture_success.html
+++ b/blowcomotion/templates/attendance/partials/capture_success.html
@@ -102,14 +102,5 @@
             }
         }
     }
-    
-    // Auto-dismiss the alert after 5 seconds
-    setTimeout(function() {
-        const alert = document.querySelector('.alert-success');
-        if (alert) {
-            alert.classList.remove('show');
-            setTimeout(() => alert.remove(), 150);
-        }
-    }, 5000);
 })();
 </script>


### PR DESCRIPTION
## Summary

The green success confirmation box on the attendance capture page disappeared automatically after 5 seconds. This removes the auto-dismiss timer in `blowcomotion/templates/attendance/partials/capture_success.html` so the confirmation persists until the user closes it with the close button (or submits more attendance, which replaces it with a fresh confirmation).

The post-save form reset (clearing checkboxes and guest fields while preserving date, event type, and notes) is unchanged.

## Testing

All 60 tests in `blowcomotion.tests.test_attendance_views` pass.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MrvfF67QGiJg6nBz8Acrjo

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrvfF67QGiJg6nBz8Acrjo)_