### PR TITLE
fix: gate header nav profile link on linked Member instead of is_staff

### DIFF
--- a/blowcomotion/templates/header.html
+++ b/blowcomotion/templates/header.html
@@ -36,12 +36,12 @@
                                     {% endif %}
                                     </li>
                             {% endfor %}
-                            {% if not request.user.is_staff %}
-                                {% if request.user.is_authenticated %}
+                            {% if request.user.is_authenticated %}
+                                {% if not request.user.is_staff or request.user.member %}
                                     <li class="header__nav-auth-mobile"><a href="{% url 'member-profile' %}">My Profile</a></li>
-                                {% else %}
-                                    <li class="header__nav-auth-mobile"><a href="{% url 'member-login' %}">Member Login</a></li>
                                 {% endif %}
+                            {% else %}
+                                <li class="header__nav-auth-mobile"><a href="{% url 'member-login' %}">Member Login</a></li>
                             {% endif %}
                         </ul>
                     </nav>
@@ -52,14 +52,16 @@
                         </div>
                     {% endif %}
                     <div class="header__member-auth ms-3">
-                        {% if request.user.is_authenticated and not request.user.is_staff %}
-                            <a href="{% url 'member-profile' %}" class="header__auth-link">My Profile</a>
-                            <span class="header__auth-sep">|</span>
-                            <form method="post" action="{% url 'member-logout' %}" style="display:inline;">
-                                {% csrf_token %}
-                                <button type="submit" class="header__auth-logout">Log Out</button>
-                            </form>
-                        {% elif not request.user.is_authenticated %}
+                        {% if request.user.is_authenticated %}
+                            {% if not request.user.is_staff or request.user.member %}
+                                <a href="{% url 'member-profile' %}" class="header__auth-link">My Profile</a>
+                                <span class="header__auth-sep">|</span>
+                                <form method="post" action="{% url 'member-logout' %}" style="display:inline;">
+                                    {% csrf_token %}
+                                    <button type="submit" class="header__auth-logout">Log Out</button>
+                                </form>
+                            {% endif %}
+                        {% else %}
                             <a href="{% url 'member-login' %}" class="header__auth-link">Member Login</a>
                         {% endif %}
                     </div>

--- a/blowcomotion/tests/test_header_nav.py
+++ b/blowcomotion/tests/test_header_nav.py
@@ -1,0 +1,48 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from blowcomotion.models import Member
+
+User = get_user_model()
+
+
+class HeaderNavMemberGateTests(TestCase):
+    """member-login page renders header.html; use it to check nav visibility."""
+
+    def setUp(self):
+        self.url = reverse("member-login")
+
+    def test_anonymous_sees_member_login_link(self):
+        response = self.client.get(self.url)
+        self.assertContains(response, "header__auth-link")
+        self.assertContains(response, "Member Login")
+
+    def test_staff_without_linked_member_sees_no_profile_or_logout(self):
+        user = User.objects.create_user(username="staffonly", password="pw", is_staff=True)
+        self.client.force_login(user)
+        response = self.client.get(self.url)
+        self.assertNotContains(response, reverse("member-profile"))
+        self.assertNotContains(response, "header__auth-logout")
+
+    def test_member_without_staff_sees_profile_link(self):
+        user = User.objects.create_user(username="memberonly", password="pw")
+        Member.objects.create(first_name="Sam", last_name="Player", email="sam@example.com", user=user)
+        self.client.force_login(user)
+        response = self.client.get(self.url)
+        self.assertContains(response, reverse("member-profile"))
+
+    def test_staff_with_linked_member_sees_profile_link(self):
+        user = User.objects.create_user(username="merged", password="pw", is_staff=True)
+        Member.objects.create(first_name="Sam", last_name="Player", email="sam2@example.com", user=user)
+        self.client.force_login(user)
+        response = self.client.get(self.url)
+        self.assertContains(response, reverse("member-profile"))
+
+    def test_nonstaff_without_linked_member_still_sees_logout(self):
+        """Orphaned User (Member deleted, on_delete=SET_NULL) must keep a way to log out."""
+        user = User.objects.create_user(username="orphaned", password="pw")
+        self.client.force_login(user)
+        response = self.client.get(self.url)
+        self.assertContains(response, reverse("member-profile"))
+        self.assertContains(response, "header__auth-logout")


### PR DESCRIPTION
Partial fix for #302 (the header.html nav portion only — production `setup_roles` rollout and user-to-group reassignment from #302 are tracked/handled separately, since the latter depends on #279 being resolved first).

## Summary
- `header.html` gated the "My Profile"/"Member Login" nav item (mobile and desktop) on `not request.user.is_staff`, assuming staff and band-member accounts are always separate people.
- Once #279 merges duplicate accounts, a staff user can also have a linked `Member` record, and this condition would hide their profile link entirely.
- Both nav gates now check `request.user.member` (the linked `Member` record) in addition to `not is_staff`, so:
  - staff with a linked Member → sees profile link + logout (the fix)
  - staff with no linked Member → sees nothing (unchanged)
  - non-staff with a linked Member → sees profile link + logout (unchanged)
  - non-staff with no linked Member (e.g. an orphaned account if a `Member` is later deleted, since `Member.user` is `on_delete=SET_NULL`) → still sees profile link + logout so they retain a way to log out (preserves prior behavior for this edge case)

## Test plan
- [x] `python manage.py test blowcomotion.tests.test_header_nav` — 5 new tests covering all four `is_staff` x `has_member` combinations
- [x] `python manage.py test` — full suite (666 tests) passing