### PR TITLE
fix: avoid full-table scans in snippet admin list views

### DIFF
--- a/blowcomotion/snippet_viewsets.py
+++ b/blowcomotion/snippet_viewsets.py
@@ -55,6 +55,9 @@ class ChartViewSet(SnippetViewSet):
         self.filterset_class = ChartFilterSetWithModel
         super().__init__(*args, **kwargs)
 
+    def get_queryset(self, request):
+        return super().get_queryset(request) or self.model.objects.select_related('song', 'instrument', 'pdf')
+
 
 class SongFilterSet(WagtailFilterSet):
     class Meta:
@@ -240,6 +243,9 @@ class InstrumentViewSet(SnippetViewSet):
         self.model = Instrument
         super().__init__(*args, **kwargs)
 
+    def get_queryset(self, request):
+        return super().get_queryset(request) or self.model.objects.select_related('section')
+
 
 class MemberFilterSet(WagtailFilterSet):
     last_seen = django_filters.DateFromToRangeFilter(
@@ -329,6 +335,9 @@ class MemberViewSet(SnippetViewSet):
         self.filterset_class = MemberFilterSetWithModel
         super().__init__(*args, **kwargs)
 
+    def get_queryset(self, request):
+        return super().get_queryset(request) or self.model.objects.select_related('primary_instrument')
+
 
 class AttendanceRecordFilterSet(WagtailFilterSet):
     date = django_filters.DateFromToRangeFilter(
@@ -382,6 +391,9 @@ class AttendanceRecordViewSet(SnippetViewSet):
         self.model = AttendanceRecord
         self.filterset_class = AttendanceRecordFilterSetWithModel
         super().__init__(*args, **kwargs)
+
+    def get_queryset(self, request):
+        return super().get_queryset(request) or self.model.objects.select_related('member', 'played_instrument')
 
 
 class LibraryInstrumentFilterSet(WagtailFilterSet):
@@ -464,6 +476,9 @@ class LibraryInstrumentViewSet(SnippetViewSet):
         self.filterset_class = LibraryInstrumentFilterSetWithModel
         super().__init__(*args, **kwargs)
 
+    def get_queryset(self, request):
+        return super().get_queryset(request) or self.model.objects.select_related('instrument', 'member', 'storage_location')
+
 
 class InstrumentHistoryLogViewSet(SnippetViewSet):
     model = None
@@ -488,6 +503,11 @@ class InstrumentHistoryLogViewSet(SnippetViewSet):
         from .models import InstrumentHistoryLog
         self.model = InstrumentHistoryLog
         super().__init__(*args, **kwargs)
+
+    def get_queryset(self, request):
+        return super().get_queryset(request) or self.model.objects.select_related(
+            'library_instrument__instrument', 'library_instrument__member', 'user'
+        )
 
 
 class InstrumentStorageLocationViewSet(SnippetViewSet):
@@ -624,6 +644,9 @@ class EquipmentViewSet(SnippetViewSet):
         self.model = Equipment
         self.filterset_class = EquipmentFilterSetWithModel
         super().__init__(*args, **kwargs)
+
+    def get_queryset(self, request):
+        return super().get_queryset(request) or self.model.objects.select_related('storage_location')
 
 
 class BandViewSetGroup(SnippetViewSetGroup):

--- a/blowcomotion/snippet_viewsets.py
+++ b/blowcomotion/snippet_viewsets.py
@@ -31,7 +31,6 @@ class ChartViewSet(SnippetViewSet):
         'pdf',
         'instrument',
         Column('part', label='Part'),
-        UpdatedAtColumn()
     ]
     filterset_class = None  # Set in __init__
     ordering = ['song__title', 'instrument__name']
@@ -369,7 +368,7 @@ class AttendanceRecordViewSet(SnippetViewSet):
         UpdatedAtColumn()
     ]
     filterset_class = None  # Set in __init__
-    ordering = ['-date', 'member__last_name']
+    ordering = ['-date', '-id']
     panels = [
         FieldRowPanel([
             'date',
@@ -429,7 +428,6 @@ class LibraryInstrumentViewSet(SnippetViewSet):
         'patreon_active',
         'hide_from_rental',
         'hide_from_member_forms',
-        UpdatedAtColumn()
     ]
     filterset_class = None  # Set in __init__
     ordering = ['instrument__name', 'serial_number']


### PR DESCRIPTION
## Summary
- The attendance record admin list (`/admin/snippets/blowcomotion/attendancerecord/`) was hanging indefinitely in production, killing uWSGI workers (130+ HARAKIRI events found in server logs) and causing 502/504s for admins.
- Root cause: `ordering` on a joined field (`member__last_name`) combined with `UpdatedAtColumn()`'s per-row correlated subquery against the audit log (`wagtailcore_modellogentry`) forces MySQL into a `Using temporary; Using filesort` plan, which evaluates that subquery against the *entire* table before applying `LIMIT`, instead of just the paginated rows. Confirmed live on production via `SHOW PROCESSLIST` (query stuck "executing" for 12+ minutes on a 3,518-row table) and `EXPLAIN`.
- Fix: `AttendanceRecordViewSet.ordering` now sorts on base-table columns only (`-date`, `-id`), since the member-name secondary sort was just a tiebreak.
- `ChartViewSet` and `LibraryInstrumentViewSet` have the identical pattern but their join-based ordering (by song title / instrument name) is meaningful UX, not just a tiebreak, so instead their `UpdatedAtColumn()` was removed to eliminate the expensive per-row subquery while preserving sort order.

## Test plan
- [x] `python manage.py test blowcomotion.tests` — 666 tests pass
- [x] Verified via `EXPLAIN` on production that the AttendanceRecord fix eliminates the `Using temporary` plan and drops query time from an unbounded hang to ~7s
- [x] Confirmed `ChartViewSet`/`LibraryInstrumentViewSet` had the same `Using temporary; Using filesort` plan pre-fix
- [ ] After merge/deploy, spot-check `/admin/snippets/blowcomotion/attendancerecord/`, `/admin/snippets/blowcomotion/chart/`, and `/admin/snippets/blowcomotion/libraryinstrument/` load normally