### PR TITLE
fix: hide unwired email preference checkboxes from member forms

### DIFF
--- a/blowcomotion/templates/blocks/member_signup_form_block.html
+++ b/blowcomotion/templates/blocks/member_signup_form_block.html
@@ -330,17 +330,6 @@
                             </div>
                         </div>
 
-                        {% if value.newsletter_opt_in %}
-                        <div class="mb-4">
-                            <div class="form-check">
-                                <input type="checkbox" class="form-check-input" id="newsletter" name="newsletter" value="yes">
-                                <label class="form-check-label" for="newsletter">
-                                    Opt-in to receive our newsletter
-                                </label>
-                            </div>
-                        </div>
-                        {% endif %}
-
                         <!-- Submit Button -->
                         <div class="text-center">
                             <button type="submit" class="site-btn btn-lg px-5">

--- a/members/forms.py
+++ b/members/forms.py
@@ -327,9 +327,6 @@ class MemberProfileForm(forms.ModelForm):
             "bio",
             "inspired_by",
             "primary_instrument",
-            "notify_rental_updates",
-            "notify_reminders",
-            "notify_announcements",
         ]
         widgets = {
             "bio": forms.Textarea(attrs={"rows": 4}),

--- a/members/templates/member/profile.html
+++ b/members/templates/member/profile.html
@@ -99,11 +99,6 @@
         {% if form.profile_photo.errors %}<div class="text-danger small">{{ form.profile_photo.errors }}</div>{% endif %}
     </div>
 
-    <h5 class="mt-4 mb-3">Notification Preferences</h5>
-    <div class="form-check mb-2">{{ form.notify_rental_updates }}<label class="form-check-label" for="{{ form.notify_rental_updates.id_for_label }}">Rental status updates</label></div>
-    <div class="form-check mb-2">{{ form.notify_reminders }}<label class="form-check-label" for="{{ form.notify_reminders.id_for_label }}">Operational reminders</label></div>
-    <div class="form-check mb-2">{{ form.notify_announcements }}<label class="form-check-label" for="{{ form.notify_announcements.id_for_label }}">Band announcements</label></div>
-
     <h5 class="mt-4 mb-3">Health &amp; Preferences</h5>
 
     <div class="mb-3">

--- a/members/tests/test_member_portal.py
+++ b/members/tests/test_member_portal.py
@@ -81,9 +81,6 @@ class ProfileViewTests(TestCase):
                 "last_name": "Player",
                 "preferred_name": "Robbie",
                 "email": "robin@example.com",
-                "notify_rental_updates": True,
-                "notify_reminders": True,
-                "notify_announcements": True,
             },
             follow=True,
         )
@@ -103,9 +100,6 @@ class ProfileViewTests(TestCase):
                     "first_name": "Robin",
                     "last_name": "Player",
                     "email": "newemail@example.com",
-                    "notify_rental_updates": True,
-                    "notify_reminders": True,
-                    "notify_announcements": True,
                 },
             )
         self.member.refresh_from_db()
@@ -151,9 +145,6 @@ class ProfileViewTests(TestCase):
                     "first_name": "Robin",
                     "last_name": "Player",
                     "email": "robin@example.com",  # same email
-                    "notify_rental_updates": True,
-                    "notify_reminders": True,
-                    "notify_announcements": True,
                 },
             )
         self.assertEqual(len(mail.outbox), 0)
@@ -166,9 +157,6 @@ class ProfileViewTests(TestCase):
                 "last_name": "Player",
                 "preferred_name": "Robbie",
                 "email": "robin@example.com",
-                "notify_rental_updates": True,
-                "notify_reminders": True,
-                "notify_announcements": True,
             },
         )
         self.assertEqual(Revision.objects.for_instance(self.member).count(), 1)


### PR DESCRIPTION
Closes #314

## Summary
- Removed the three notification-preference checkboxes (rental updates, reminders, announcements) from the member portal profile edit form (`MemberProfileForm` / `profile.html`). Confirmed via repo-wide grep that these `Member` model fields are never read before sending rental/reminder/announcement emails — checking or unchecking them had no effect.
- Removed the newsletter opt-in checkbox from the public member signup form (`member_signup_form_block.html`). The signup view (`_process_member_signup`) never reads the posted `newsletter` field and `Member` has no field to store it in, so this checkbox was also dead.
- Left the underlying `Member` model fields (`notify_rental_updates`, `notify_reminders`, `notify_announcements`) and their `True` defaults untouched — this is a form/template visibility change only, not a schema change.
- Left the sibling `newsletter_opt_in` checkboxes on the contact/join-band/booking/donate form blocks alone — those are wired to their respective submission models and are out of scope.

## Test plan
- [x] `python manage.py test members blowcomotion` — 304 tests pass
- [x] Manually load the member signup form and confirm no newsletter checkbox appears
- [x] Manually load a member's profile edit page and confirm no "Notification Preferences" section appears