### PR TITLE
fix: index related fields correctly for library instrument search

### DIFF
--- a/blowcomotion/models/instruments.py
+++ b/blowcomotion/models/instruments.py
@@ -143,9 +143,18 @@ class LibraryInstrument(DraftStateMixin, RevisionMixin, LockableMixin, Clusterab
 
     search_fields = [
         index.SearchField("serial_number"),
-        index.SearchField("instrument_name"),
         index.SearchField("comments"),
         index.AutocompleteField("serial_number"),
+        index.RelatedFields("instrument", [
+            index.SearchField("name"),
+            index.AutocompleteField("name"),
+        ]),
+        index.RelatedFields("member", [
+            index.SearchField("first_name"),
+            index.SearchField("last_name"),
+            index.AutocompleteField("first_name"),
+            index.AutocompleteField("last_name"),
+        ]),
     ]
 
     class Meta:

--- a/blowcomotion/snippet_viewsets.py
+++ b/blowcomotion/snippet_viewsets.py
@@ -418,7 +418,6 @@ class LibraryInstrumentViewSet(SnippetViewSet):
     menu_label = 'Library Instruments'
     menu_name = 'library_instruments'
     menu_icon = 'french-horn'
-    search_fields = ('instrument__name', 'serial_number', 'member__first_name', 'member__last_name', 'comments')
     list_display = [
         'instrument',
         'serial_number',


### PR DESCRIPTION
Fixes #321

## Summary
- `index.SearchField("instrument__name")` / `member__first_name` / `member__last_name` don't work — Wagtail's `SearchField` calls `getattr(obj, field_name)` literally and doesn't understand Django's `__` relation-traversal syntax. This caused `django.db.utils.OperationalError: no such column: instrument__name` when the search index was queried.
- Replaced with `index.RelatedFields("instrument", [...])` / `index.RelatedFields("member", [...])`, each including an `AutocompleteField` alongside the `SearchField` — the admin snippet listing search uses Wagtail's autocomplete query path (triggered by the existing `AutocompleteField("serial_number")`), which only matches fields explicitly tagged `AutocompleteField`.
- Removed the now-incompatible `search_fields` restriction on `LibraryInstrumentViewSet` in `snippet_viewsets.py`, since Wagtail's field-restriction check only recognizes top-level `SearchField` names, never names nested inside `RelatedFields`.

## Test plan
- [x] `python manage.py test blowcomotion instruments` — 216 tests, all passing
- [x] Rebuilt search index locally (`python manage.py update_index`) and confirmed via shell that autocomplete search for `megan` correctly returns the instrument rented to Megan Hill
- [ ] Run `python manage.py update_index` on production after deploy so the new indexed fields are searchable