### PR TITLE
Add instrument gallery admin page and consolidate library admin menu

### DIFF
--- a/blowcomotion/templates/wagtailadmin/instrument_library_gallery.html
+++ b/blowcomotion/templates/wagtailadmin/instrument_library_gallery.html
@@ -1,0 +1,167 @@
+{% extends "wagtailadmin/base.html" %}
+{% load wagtailimages_tags %}
+{% block titletag %}Instrument Gallery{% endblock %}
+{% block content %}
+<div class="nice-padding">
+    <h1>Instrument Gallery</h1>
+    <p>Browse every instrument in the library inventory with its photos. Use the filters below to narrow the list.</p>
+
+    <style>
+        .instrument-gallery-filters {
+            display: flex;
+            gap: 1rem;
+            flex-wrap: wrap;
+            align-items: flex-end;
+            margin-bottom: 1.5rem;
+        }
+        .instrument-gallery-filters label {
+            display: block;
+            font-weight: bold;
+            margin-bottom: 0.25rem;
+        }
+        .instrument-gallery-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+            gap: 1rem;
+            margin-bottom: 1.5rem;
+        }
+        .instrument-gallery-card {
+            border: 1px solid var(--w-color-border-furniture);
+            border-radius: 6px;
+            padding: 0.75rem;
+            background: var(--w-color-surface-page);
+        }
+        .instrument-gallery-card h3 {
+            margin: 0.5rem 0 0.25rem;
+            font-size: 1rem;
+        }
+        .instrument-gallery-card h3 a {
+            color: var(--w-color-text-link-default);
+        }
+        .instrument-gallery-photo-main {
+            width: 100%;
+            aspect-ratio: 1 / 1;
+            object-fit: cover;
+            border-radius: 4px;
+            background: var(--w-color-surface-field-inactive);
+        }
+        .instrument-gallery-no-photo {
+            width: 100%;
+            aspect-ratio: 1 / 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            border-radius: 4px;
+            background: var(--w-color-surface-field-inactive);
+            color: var(--w-color-text-meta);
+        }
+        .instrument-gallery-thumbnails {
+            display: flex;
+            gap: 0.25rem;
+            margin-top: 0.25rem;
+            flex-wrap: wrap;
+        }
+        .instrument-gallery-thumbnails img {
+            width: 48px;
+            height: 48px;
+            object-fit: cover;
+            border-radius: 3px;
+        }
+        .instrument-gallery-meta {
+            font-size: 0.85rem;
+            color: var(--w-color-text-meta);
+        }
+        .instrument-gallery-pagination {
+            display: flex;
+            gap: 1rem;
+            align-items: center;
+        }
+    </style>
+
+    <form method="get" class="instrument-gallery-filters">
+        <div>
+            <label for="id_status">Status</label>
+            <select name="status" id="id_status">
+                <option value="">All</option>
+                {% for value, label in status_choices %}
+                <option value="{{ value }}"{% if value == selected_status %} selected{% endif %}>{{ label }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div>
+            <label for="id_instrument">Instrument</label>
+            <select name="instrument" id="id_instrument">
+                <option value="">All</option>
+                {% for instrument in instrument_choices %}
+                <option value="{{ instrument.pk }}"{% if selected_instrument == instrument.pk|stringformat:"s" %} selected{% endif %}>{{ instrument.name }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div>
+            <label for="id_storage_location">Storage Location</label>
+            <select name="storage_location" id="id_storage_location">
+                <option value="">All</option>
+                {% for location in storage_location_choices %}
+                <option value="{{ location.pk }}"{% if selected_storage_location == location.pk|stringformat:"s" %} selected{% endif %}>{{ location.name }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div>
+            <label for="id_q">Search</label>
+            <input type="text" name="q" id="id_q" value="{{ query }}" placeholder="Serial number or instrument name">
+        </div>
+        <div>
+            <button type="submit" class="button">Filter</button>
+            <a href="{% url 'instrument_library_gallery' %}" class="button button-secondary">Clear</a>
+        </div>
+    </form>
+
+    {% if page_obj %}
+    <div class="instrument-gallery-grid">
+        {% for li in page_obj %}
+        <div class="instrument-gallery-card">
+            {% with photos=li.photos.all %}
+            {% if photos %}
+            {% image photos.0.image fill-300x300 as main_photo %}
+            <img class="instrument-gallery-photo-main" src="{{ main_photo.url }}" alt="{{ li.instrument.name }}">
+            {% if photos|length > 1 %}
+            <div class="instrument-gallery-thumbnails">
+                {% for photo in photos %}
+                {% image photo.image fill-100x100 as thumb %}
+                <img src="{{ thumb.url }}" alt="{{ li.instrument.name }} photo">
+                {% endfor %}
+            </div>
+            {% endif %}
+            {% else %}
+            <div class="instrument-gallery-no-photo">No photo</div>
+            {% endif %}
+            {% endwith %}
+            <h3><a href="{% url 'wagtailsnippets_blowcomotion_libraryinstrument:edit' li.pk %}">{{ li.instrument.name }}</a></h3>
+            <div class="instrument-gallery-meta">
+                <div>Serial: {{ li.serial_number }}</div>
+                <div>Status: {{ li.get_status_display }}</div>
+                {% if li.member %}
+                <div>Member: {{ li.member }}</div>
+                {% endif %}
+                {% if li.storage_location %}
+                <div>Location: {{ li.storage_location }}</div>
+                {% endif %}
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+
+    <div class="instrument-gallery-pagination">
+        {% if page_obj.has_previous %}
+        <a class="button button-small" href="?{{ querystring }}page={{ page_obj.previous_page_number }}">Previous</a>
+        {% endif %}
+        <span>Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
+        {% if page_obj.has_next %}
+        <a class="button button-small" href="?{{ querystring }}page={{ page_obj.next_page_number }}">Next</a>
+        {% endif %}
+    </div>
+    {% else %}
+    <p>No instruments to display.</p>
+    {% endif %}
+</div>
+{% endblock %}

--- a/blowcomotion/templates/wagtailadmin/instrument_library_gallery.html
+++ b/blowcomotion/templates/wagtailadmin/instrument_library_gallery.html
@@ -5,6 +5,9 @@
 <div class="nice-padding">
     <h1>Instrument Gallery</h1>
     <p>Browse every instrument in the library inventory with its photos. Use the filters below to narrow the list.</p>
+    {% if perms.blowcomotion.add_libraryinstrument %}
+    <p><a href="{% url 'wagtailsnippets_blowcomotion_libraryinstrument:add' %}" class="button bicolor button--icon"><span class="icon-wrapper"><svg class="icon icon-plus icon" aria-hidden="true"><use href="#icon-plus"></use></svg></span>Create New</a></p>
+    {% endif %}
 
     <style>
         .instrument-gallery-filters {

--- a/blowcomotion/tests/test_admin_menu_visibility.py
+++ b/blowcomotion/tests/test_admin_menu_visibility.py
@@ -32,15 +32,18 @@ class AdminMenuVisibilityTests(TestCase):
         html = self._get_admin_home_html(user)
         self.assertIn('Utilities', html)
 
-    def test_library_manager_sees_rental_requests(self):
+    def test_library_manager_sees_instrument_library_menu(self):
         access_admin = Permission.objects.get(content_type__app_label='wagtailadmin', codename='access_admin')
         change_li = Permission.objects.get(content_type__app_label='blowcomotion', codename='change_libraryinstrument')
         user = User.objects.create_user(username='librarian', password='pw', is_staff=True)
         user.user_permissions.add(access_admin, change_li)
         html = self._get_admin_home_html(user)
+        self.assertIn('Instrument Library', html)
         self.assertIn('Rental Requests', html)
-        # Library Manager needs "Utilities" visible to reach "Library Dashboards" nested inside it.
-        self.assertIn('Utilities', html)
+        self.assertIn('Gallery', html)
+        # All library pages now live under "Instrument Library"; a librarian
+        # with no export/gig permissions has no reason to see "Utilities".
+        self.assertNotIn('Utilities', html)
 
     def test_gig_booker_sees_utilities_menu(self):
         access_admin = Permission.objects.get(content_type__app_label='wagtailadmin', codename='access_admin')
@@ -63,6 +66,7 @@ class AdminMenuVisibilityTests(TestCase):
         user = User.objects.create_superuser(username='admin', email='admin@example.com', password='pw')
         html = self._get_admin_home_html(user)
         self.assertIn('Utilities', html)
+        self.assertIn('Instrument Library', html)
         self.assertIn('Rental Requests', html)
         self.assertIn('Import Charts', html)
 

--- a/blowcomotion/wagtail_hooks.py
+++ b/blowcomotion/wagtail_hooks.py
@@ -16,6 +16,7 @@ from gigs.views import sync_gigs_admin
 from instruments.views import (
     export_library_instruments_csv,
     instrument_library_available,
+    instrument_library_gallery,
     instrument_library_needs_repair,
     instrument_library_rented,
     rental_request_return,
@@ -99,6 +100,11 @@ def register_admin_urls():
             instrument_library_needs_repair,
             name="instrument_library_needs_repair",
         ),
+        path(
+            "instrument-library/gallery/",
+            instrument_library_gallery,
+            name="instrument_library_gallery",
+        ),
         # TODO(#250): delete — replaced by Rental Requests dashboard
         # path(
         #     "instrument-library/manage/",
@@ -128,7 +134,6 @@ EXPORTS_PERMISSIONS = ['blowcomotion.access_dev_tools', 'blowcomotion.access_rea
 # by anything nested inside it (PermissionSubmenuMenuItem.is_shown does not
 # fall back to "show if any child is visible").
 UTILITIES_PERMISSIONS = EXPORTS_PERMISSIONS + [
-    'blowcomotion.change_libraryinstrument',  # Library Dashboards submenu
     'blowcomotion.change_cachedgig',  # Sync Gigs
 ]
 
@@ -151,20 +156,9 @@ def register_management_menu_item():
                             permission='blowcomotion.access_real_data_exports'),
     ])
 
-    library_dashboards_submenu = Menu(items=[
-        PermissionMenuItem('Library: Rented', reverse('instrument_library_rented'), icon_name='french-horn',
-                            permission='blowcomotion.change_libraryinstrument'),
-        PermissionMenuItem('Library: Available', reverse('instrument_library_available'), icon_name='french-horn',
-                            permission='blowcomotion.change_libraryinstrument'),
-        PermissionMenuItem('Library: Maintenance', reverse('instrument_library_needs_repair'), icon_name='warning',
-                            permission='blowcomotion.change_libraryinstrument'),
-    ])
-
     submenu = Menu(items=[
         PermissionSubmenuMenuItem('Exports', exports_submenu, icon_name='download',
                                    permission=EXPORTS_PERMISSIONS),
-        PermissionSubmenuMenuItem('Library Dashboards', library_dashboards_submenu, icon_name='french-horn',
-                                   permission='blowcomotion.change_libraryinstrument'),
         PermissionMenuItem('Sync Gigs', reverse('sync_gigs'), icon_name='cog',
                             permission='blowcomotion.change_cachedgig'),
     ])
@@ -186,12 +180,21 @@ def register_management_menu_item():
 
 
 @hooks.register("register_admin_menu_item")
-def register_rental_requests_menu_item():
-    return PermissionMenuItem(
-        "Rental Requests",
-        reverse("rental_requests_dashboard"),
-        icon_name="french-horn",
-        order=295,
+def register_instrument_library_menu_item():
+    library_submenu = Menu(items=[
+        PermissionMenuItem('Rental Requests', reverse('rental_requests_dashboard'), icon_name='french-horn',
+                            permission='blowcomotion.change_libraryinstrument'),
+        PermissionMenuItem('Gallery', reverse('instrument_library_gallery'), icon_name='image',
+                            permission='blowcomotion.change_libraryinstrument'),
+        PermissionMenuItem('Rented', reverse('instrument_library_rented'), icon_name='french-horn',
+                            permission='blowcomotion.change_libraryinstrument'),
+        PermissionMenuItem('Available', reverse('instrument_library_available'), icon_name='french-horn',
+                            permission='blowcomotion.change_libraryinstrument'),
+        PermissionMenuItem('Maintenance', reverse('instrument_library_needs_repair'), icon_name='warning',
+                            permission='blowcomotion.change_libraryinstrument'),
+    ])
+    return PermissionSubmenuMenuItem(
+        'Instrument Library', library_submenu, icon_name='french-horn', order=295,
         permission='blowcomotion.change_libraryinstrument',
     )
 

--- a/instruments/tests/test_instrument_library_gallery.py
+++ b/instruments/tests/test_instrument_library_gallery.py
@@ -55,6 +55,18 @@ class InstrumentLibraryGalleryTests(TestCase):
         self.assertContains(response, "SN12345")
         self.assertNotContains(response, "No photo")
 
+    def test_create_new_button_requires_add_permission(self):
+        self.client.login(username='librarian', password='pw')
+        response = self.client.get(reverse('instrument_library_gallery'))
+        self.assertNotContains(response, "Create New")
+
+        ct = ContentType.objects.get_for_model(LibraryInstrument)
+        add_perm = Permission.objects.get(content_type=ct, codename='add_libraryinstrument')
+        self.librarian.user_permissions.add(add_perm)
+        response = self.client.get(reverse('instrument_library_gallery'))
+        self.assertContains(response, "Create New")
+        self.assertContains(response, reverse('wagtailsnippets_blowcomotion_libraryinstrument:add'))
+
     def test_no_photo_placeholder(self):
         instrument = make_instrument()
         make_library_instrument(instrument, serial="SN99999")

--- a/instruments/tests/test_instrument_library_gallery.py
+++ b/instruments/tests/test_instrument_library_gallery.py
@@ -1,0 +1,138 @@
+"""
+Unit tests for the Instrument Gallery admin dashboard view.
+"""
+from wagtail.images import get_image_model
+from wagtail.images.tests.utils import get_test_image_file
+
+from django.contrib.auth.models import ContentType, Permission, User
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from blowcomotion.models import Instrument, LibraryInstrument, LibraryInstrumentPhoto
+
+Image = get_image_model()
+
+
+def make_instrument(name="Trumpet"):
+    return Instrument.objects.create(name=name)
+
+
+def make_library_instrument(instrument, status=LibraryInstrument.STATUS_AVAILABLE, serial="SN001"):
+    return LibraryInstrument.objects.create(
+        instrument=instrument, serial_number=serial, status=status
+    )
+
+
+class InstrumentLibraryGalleryTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        ct = ContentType.objects.get_for_model(LibraryInstrument)
+        self.change_perm = Permission.objects.get(content_type=ct, codename='change_libraryinstrument')
+        self.access_admin_perm = Permission.objects.get(
+            content_type__app_label='wagtailadmin', codename='access_admin'
+        )
+        self.librarian = User.objects.create_user(username='librarian', password='pw', is_staff=True)
+        self.librarian.user_permissions.add(self.change_perm, self.access_admin_perm)
+
+    def test_staff_without_permission_denied(self):
+        user = User.objects.create_user(username='staff', password='pw', is_staff=True)
+        user.user_permissions.add(self.access_admin_perm)
+        self.client.login(username='staff', password='pw')
+        response = self.client.get(reverse('instrument_library_gallery'))
+        self.assertRedirects(
+            response, reverse('wagtailadmin_home'), fetch_redirect_response=False
+        )
+
+    def test_library_manager_sees_instrument_and_photo(self):
+        instrument = make_instrument()
+        li = make_library_instrument(instrument, serial="SN12345")
+        image = Image.objects.create(title="Trumpet photo", file=get_test_image_file())
+        LibraryInstrumentPhoto.objects.create(library_instrument=li, image=image)
+
+        self.client.login(username='librarian', password='pw')
+        response = self.client.get(reverse('instrument_library_gallery'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "SN12345")
+        self.assertNotContains(response, "No photo")
+
+    def test_no_photo_placeholder(self):
+        instrument = make_instrument()
+        make_library_instrument(instrument, serial="SN99999")
+
+        self.client.login(username='librarian', password='pw')
+        response = self.client.get(reverse('instrument_library_gallery'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "No photo")
+
+    def test_status_filter_narrows_results(self):
+        instrument = make_instrument()
+        make_library_instrument(instrument, status=LibraryInstrument.STATUS_AVAILABLE, serial="AVAIL001")
+        make_library_instrument(instrument, status=LibraryInstrument.STATUS_NEEDS_REPAIR, serial="REPAIR001")
+
+        self.client.login(username='librarian', password='pw')
+        response = self.client.get(
+            reverse('instrument_library_gallery'), {'status': LibraryInstrument.STATUS_NEEDS_REPAIR}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "REPAIR001")
+        self.assertNotContains(response, "AVAIL001")
+
+    def test_pagination_page_two(self):
+        instrument = make_instrument()
+        LibraryInstrument.objects.bulk_create([
+            LibraryInstrument(
+                instrument=instrument,
+                serial_number=f"SN{i:03d}",
+                status=LibraryInstrument.STATUS_AVAILABLE,
+            )
+            for i in range(25)
+        ])
+
+        self.client.login(username='librarian', password='pw')
+        response = self.client.get(reverse('instrument_library_gallery'), {'page': 2})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Page 2 of 2")
+
+    def test_bad_page_number_does_not_500(self):
+        instrument = make_instrument()
+        make_library_instrument(instrument, serial="SN00001")
+
+        self.client.login(username='librarian', password='pw')
+        response = self.client.get(reverse('instrument_library_gallery'), {'page': 'not-a-number'})
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get(reverse('instrument_library_gallery'), {'page': 999})
+        self.assertEqual(response.status_code, 200)
+
+    def test_bad_fk_filter_params_do_not_500(self):
+        instrument = make_instrument()
+        make_library_instrument(instrument, serial="SN00001")
+
+        self.client.login(username='librarian', password='pw')
+        response = self.client.get(
+            reverse('instrument_library_gallery'), {'instrument': 'abc', 'storage_location': 'xyz'}
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_query_filter_matches_serial_and_preserves_filters_on_page_two(self):
+        instrument = make_instrument()
+        other_instrument = make_instrument(name="Trombone")
+        LibraryInstrument.objects.bulk_create([
+            LibraryInstrument(
+                instrument=instrument,
+                serial_number=f"MATCH{i:03d}",
+                status=LibraryInstrument.STATUS_AVAILABLE,
+            )
+            for i in range(25)
+        ])
+        make_library_instrument(other_instrument, status=LibraryInstrument.STATUS_AVAILABLE, serial="OTHER001")
+
+        self.client.login(username='librarian', password='pw')
+        response = self.client.get(
+            reverse('instrument_library_gallery'), {'q': 'MATCH', 'page': 2}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Page 2 of 2")
+        self.assertNotContains(response, "OTHER001")
+        # the filter must be preserved in the pagination links on page 2
+        self.assertContains(response, "q=MATCH")

--- a/instruments/tests/test_library_rental_dashboard_permissions.py
+++ b/instruments/tests/test_library_rental_dashboard_permissions.py
@@ -11,6 +11,7 @@ DASHBOARD_URL_NAMES = [
     'instrument_library_rented',
     'instrument_library_available',
     'instrument_library_needs_repair',
+    'instrument_library_gallery',
     'rental_requests_dashboard',
 ]
 

--- a/instruments/views.py
+++ b/instruments/views.py
@@ -10,6 +10,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import permission_required
 from django.core.mail import send_mail
 from django.core.management import call_command
+from django.core.paginator import Paginator
 from django.db.models import Q
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -18,9 +19,11 @@ from django.utils import timezone
 from django.views.decorators.http import require_http_methods
 
 from blowcomotion.models import (
+    Instrument,
     InstrumentHistoryLog,
     InstrumentRentalNagLog,
     InstrumentRentalRequestSubmission,
+    InstrumentStorageLocation,
     LibraryInstrument,
     Member,
     SiteSettings,
@@ -86,6 +89,60 @@ def instrument_library_needs_repair(request):
         {
             'page_title': 'Instruments Needing Repair / Maintenance',
             'instruments': instruments,
+        },
+    )
+
+
+GALLERY_PAGE_SIZE = 24
+
+
+@permission_required('blowcomotion.change_libraryinstrument', raise_exception=True)
+def instrument_library_gallery(request):
+    instruments = (
+        LibraryInstrument.objects.select_related('instrument', 'member', 'storage_location')
+        .prefetch_related('photos__image')
+        .order_by('instrument__name', 'serial_number')
+    )
+
+    status = request.GET.get('status', '')
+    instrument_id = request.GET.get('instrument', '')
+    storage_location_id = request.GET.get('storage_location', '')
+    query = request.GET.get('q', '').strip()
+
+    if status:
+        instruments = instruments.filter(status=status)
+    if instrument_id.isdigit():
+        instruments = instruments.filter(instrument_id=instrument_id)
+    if storage_location_id.isdigit():
+        instruments = instruments.filter(storage_location_id=storage_location_id)
+    if query:
+        instruments = instruments.filter(
+            Q(serial_number__icontains=query) | Q(instrument__name__icontains=query)
+        )
+
+    paginator = Paginator(instruments, GALLERY_PAGE_SIZE)
+    page_obj = paginator.get_page(request.GET.get('page'))
+
+    querystring = request.GET.copy()
+    querystring.pop('page', None)
+    querystring = querystring.urlencode()
+    if querystring:
+        querystring += '&'
+
+    return render(
+        request,
+        'wagtailadmin/instrument_library_gallery.html',
+        {
+            'page_title': 'Instrument Gallery',
+            'page_obj': page_obj,
+            'status_choices': LibraryInstrument.STATUS_CHOICES,
+            'instrument_choices': Instrument.objects.order_by('name'),
+            'storage_location_choices': InstrumentStorageLocation.objects.order_by('name'),
+            'selected_status': status,
+            'selected_instrument': instrument_id,
+            'selected_storage_location': storage_location_id,
+            'query': query,
+            'querystring': querystring,
         },
     )
 


### PR DESCRIPTION
## Summary

- Adds a paginated, filterable card-grid gallery of all library instruments with their photos at `/admin/instrument-library/gallery/`, gated by the `change_libraryinstrument` permission (Library Manager role).
- Consolidates Rental Requests, Gallery, and the library dashboards (Rented/Available/Maintenance) into a single top-level "Instrument Library" admin menu.
- Removes Library Dashboards from Utilities menu for librarians without export/gig permissions.

## Testing

- 129 tests pass: instruments app + blowcomotion.tests.test_admin_menu_visibility
- Includes 8 new gallery tests covering pagination, filtering, and permission checks
- isort checks pass (inline imports flagged during commit but compliant with sorting rules)