### PR TITLE
feat: integrate website analytics metrics

### DIFF
--- a/blowcomotion/settings/base.py
+++ b/blowcomotion/settings/base.py
@@ -345,6 +345,11 @@ WAGTAILDOCS_MAX_UPLOAD_SIZE = 10 * 1024 * 1024  # 10MB
 WAGTAILIMAGES_JPEG_QUALITY = 85
 WAGTAILIMAGES_AVIF_QUALITY = 80
 
+# Google Analytics (GA4)
+# Set GOOGLE_ANALYTICS_ID (e.g. "G-XXXXXXXXXX") in local.py for production.
+# When unset, the gtag.js snippet is not rendered.
+GOOGLE_ANALYTICS_ID = None
+
 # reCAPTCHA Settings
 # Set RECAPTCHA_PUBLIC_KEY and RECAPTCHA_PRIVATE_KEY in local.py for production.
 # If keys are missing, validation is skipped only when DEBUG=True; when DEBUG=False submissions are rejected.

--- a/blowcomotion/templates/head.html
+++ b/blowcomotion/templates/head.html
@@ -6,6 +6,17 @@
     {% endif %}
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
+    {% get_google_analytics_id as google_analytics_id %}
+    {% if google_analytics_id %}
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ google_analytics_id|urlencode }}"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '{{ google_analytics_id|escapejs }}');
+    </script>
+    {% endif %}
+
     {# Force all links in the live preview panel to be opened in a new tab #}
     {% if request.in_preview_panel %}
     <base target="_blank">

--- a/blowcomotion/templatetags/blowco_tags.py
+++ b/blowcomotion/templatetags/blowco_tags.py
@@ -43,3 +43,11 @@ def get_recaptcha_site_key():
     public_key = getattr(django_settings, 'RECAPTCHA_PUBLIC_KEY', None)
     private_key = getattr(django_settings, 'RECAPTCHA_PRIVATE_KEY', None)
     return public_key if (public_key and private_key) else ''
+
+
+@register.simple_tag
+def get_google_analytics_id():
+    """
+    Return the configured Google Analytics (GA4) measurement ID, or empty string if unset.
+    """
+    return getattr(django_settings, 'GOOGLE_ANALYTICS_ID', None) or ''

--- a/blowcomotion/tests/test_google_analytics.py
+++ b/blowcomotion/tests/test_google_analytics.py
@@ -1,0 +1,66 @@
+"""
+Unit tests for Google Analytics (GA4) integration.
+"""
+
+from django.template import Context, Template
+from django.test import TestCase, override_settings
+
+from blowcomotion.templatetags.blowco_tags import get_google_analytics_id
+
+
+class GetGoogleAnalyticsIdTagTests(TestCase):
+    """Test cases for the get_google_analytics_id template tag."""
+
+    @override_settings(GOOGLE_ANALYTICS_ID=None)
+    def test_returns_empty_string_when_unset(self):
+        self.assertEqual(get_google_analytics_id(), '')
+
+    @override_settings(GOOGLE_ANALYTICS_ID='')
+    def test_returns_empty_string_when_blank(self):
+        self.assertEqual(get_google_analytics_id(), '')
+
+    @override_settings(GOOGLE_ANALYTICS_ID='G-TESTID123')
+    def test_returns_id_when_configured(self):
+        self.assertEqual(get_google_analytics_id(), 'G-TESTID123')
+
+
+class GoogleAnalyticsSnippetRenderingTests(TestCase):
+    """Test cases for conditional rendering of the gtag.js snippet."""
+
+    def _render(self):
+        template = Template(
+            "{% load blowco_tags %}"
+            "{% get_google_analytics_id as google_analytics_id %}"
+            "{% if google_analytics_id %}"
+            "<script async src=\"https://www.googletagmanager.com/gtag/js?id={{ google_analytics_id|urlencode }}\"></script>"
+            "gtag('config', '{{ google_analytics_id|escapejs }}');"
+            "{% endif %}"
+        )
+        return template.render(Context({}))
+
+    @override_settings(GOOGLE_ANALYTICS_ID=None)
+    def test_snippet_omitted_when_unset(self):
+        rendered = self._render()
+        self.assertNotIn('googletagmanager.com', rendered)
+        self.assertNotIn('gtag(', rendered)
+
+    @override_settings(GOOGLE_ANALYTICS_ID='G-TESTID123')
+    def test_snippet_included_when_configured(self):
+        rendered = self._render()
+        self.assertIn('googletagmanager.com/gtag/js?id=G-TESTID123', rendered)
+        self.assertIn("gtag('config',", rendered)
+        self.assertIn('TESTID123', rendered)
+
+
+class HomePageRendersAnalyticsSnippetTests(TestCase):
+    """Integration tests confirming the base template renders (or omits) the snippet."""
+
+    @override_settings(GOOGLE_ANALYTICS_ID=None)
+    def test_404_page_omits_snippet_when_unset(self):
+        response = self.client.get('/this-page-does-not-exist/')
+        self.assertNotContains(response, 'googletagmanager.com', status_code=404)
+
+    @override_settings(GOOGLE_ANALYTICS_ID='G-TESTID123')
+    def test_404_page_includes_snippet_when_configured(self):
+        response = self.client.get('/this-page-does-not-exist/')
+        self.assertContains(response, 'googletagmanager.com/gtag/js?id=G-TESTID123', status_code=404)


### PR DESCRIPTION
Closes #72

## Summary

- Add a `GOOGLE_ANALYTICS_ID` setting in `blowcomotion/settings/base.py` (defaults to `None`); the real GA4 measurement ID is set in the gitignored `local.py` on production.
- Add a `get_google_analytics_id` template tag in `blowcomotion/templatetags/blowco_tags.py`, following the existing `get_recaptcha_site_key` pattern, that reads the setting and returns an empty string when unset.
- Render the standard GA4 `gtag.js` snippet in `blowcomotion/templates/head.html`, gated on the tag returning a non-empty value, so nothing is emitted until an ID is configured.
- Since every page (public, member portal, and error pages) extends the shared `blowcomotion/templates/base.html`, the snippet is included site-wide automatically; the Wagtail admin uses its own separate base template and is unaffected.

## Test plan

- [x] `isort blowcomotion/` — clean (also enforced by the pre-commit hook)
- [x] `python manage.py test blowcomotion` — 109 tests pass
- [x] `python manage.py test` (full suite) — 706 tests pass
- [x] New tests in `blowcomotion/tests/test_google_analytics.py` verify the template tag returns empty/actual values correctly, and that a rendered page (404 template, which extends `base.html`) omits the snippet when `GOOGLE_ANALYTICS_ID` is unset and includes it with the correct measurement ID when set
- [ ] Manual/production step: set `GOOGLE_ANALYTICS_ID = "G-XXXXXXXXXX"` in `local.py` on production and verify real-time traffic appears in the Google Analytics dashboard