### PR TITLE
fix: show recaptcha errors on instrument rental form

### DIFF
--- a/instruments/tests/test_instrument_rental.py
+++ b/instruments/tests/test_instrument_rental.py
@@ -343,6 +343,26 @@ class InstrumentRentalRequestViewTest(TestCase):
         response = self._post()
         self.assertNotIn("patreon_url", response.context)
 
+    def test_post_shows_recaptcha_error(self):
+        with patch(
+            "members.views._validate_recaptcha",
+            return_value=(False, "reCAPTCHA verification failed. Please try again."),
+        ):
+            response = self._post()
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "reCAPTCHA verification failed. Please try again.")
+        self.assertEqual(InstrumentRentalRequestSubmission.objects.count(), 0)
+
+    def test_post_recaptcha_failure_preserves_submitted_choice(self):
+        with patch(
+            "members.views._validate_recaptcha",
+            return_value=(False, "reCAPTCHA verification failed. Please try again."),
+        ):
+            response = self._post({"notes": "prefer small bore"})
+        self.assertEqual(
+            response.context["form"].data.get("instrument"), str(self.instrument.pk)
+        )
+
 
 class InstrumentRentalFormV2Test(TestCase):
     def setUp(self):

--- a/members/templates/member/instrument_rental_request.html
+++ b/members/templates/member/instrument_rental_request.html
@@ -17,6 +17,7 @@
     {% endif %}
   </div>
 {% else %}
+  {% if recaptcha_error %}<div class="alert alert-danger">{{ recaptcha_error }}</div>{% endif %}
   <p>Your contact information on file will be included with this request.
     <a href="{% url 'member-profile' %}">Need to update it?</a>
   </p>

--- a/members/views.py
+++ b/members/views.py
@@ -473,7 +473,7 @@ def instrument_rental_request(request):
     if request.method == "POST":
         is_valid_captcha, captcha_error = _validate_recaptcha(request)
         if not is_valid_captcha:
-            form = InstrumentRentalRequestForm()
+            form = InstrumentRentalRequestForm(request.POST)
             return render(request, "member/instrument_rental_request.html", {
                 "member": member,
                 "form": form,


### PR DESCRIPTION
Closes #267

## Summary
- The member-portal instrument rental request view (`members/views.py`, `instrument_rental_request`) already computed and passed `recaptcha_error` into the template context on reCAPTCHA validation failure, but `member/instrument_rental_request.html` never rendered it — so a failed reCAPTCHA check silently dropped the submission with no feedback to the user, matching the bug reported in production.
- Added the same `{% if recaptcha_error %}` alert block already used by the other member-portal templates (profile, get_access, login, set_password, password_reset) to `instrument_rental_request.html`.
- Changed the reCAPTCHA-failure branch to rebuild the form with `request.POST` instead of a blank form, so the member's instrument choices and notes are preserved instead of being wiped out when they have to resubmit — consistent with how `profile_view` and `get_access_view` already handle this case.
- Confirmed via grep that other `_validate_recaptcha` callers (login, set_password, password_reset, get_access, profile) already display the error correctly; this was an isolated gap in a single template, not a shared-helper bug.

## Test plan
- [x] `python manage.py test instruments` — 125 tests, all passing
- [x] `python manage.py test members` — 202 tests, all passing
- [x] `python manage.py test` (full suite) — 701 tests, all passing
- [x] Added `test_post_shows_recaptcha_error`, asserting the error message renders in the response body when `_validate_recaptcha` returns `False`
- [x] Added `test_post_recaptcha_failure_preserves_submitted_choice`, asserting the submitted instrument choice survives a reCAPTCHA failure