### PR TITLE
feat: add Patreon stats to member profile

### DIFF
--- a/members/templates/member/profile.html
+++ b/members/templates/member/profile.html
@@ -23,6 +23,33 @@
         <a href="{% url 'member-attendance' %}" class="btn btn-sm site-btn">View Attendance Record</a>
     </div>
 </div>
+{% if patreon_configured %}
+<div class="card mb-4">
+    <div class="card-body">
+        <strong>Patreon:</strong>
+        {% if patreon_status is None %}
+            status temporarily unavailable
+        {% elif patreon_status.is_active %}
+            <span class="text-success">Active patron</span>
+            {% if patreon_status.pledge_cents is not None %}
+                &mdash; ${% widthratio patreon_status.pledge_cents 100 1 %}/mo
+            {% endif %}
+            {% if patreon_status.patron_since %}
+                <div class="form-text mb-0">Patron since {{ patreon_status.patron_since|date:"Y-m-d" }}</div>
+            {% endif %}
+            {% if patreon_status.last_charge_date %}
+                <div class="form-text mb-0">Last charge {{ patreon_status.last_charge_date|date:"Y-m-d" }}{% if patreon_status.last_charge_status %} ({{ patreon_status.last_charge_status }}){% endif %}</div>
+            {% endif %}
+            {% if patreon_status.lifetime_cents is not None %}
+                <div class="form-text mb-0">Lifetime support: ${% widthratio patreon_status.lifetime_cents 100 1 %}</div>
+            {% endif %}
+        {% else %}
+            <span class="text-danger">Not found or inactive</span>
+            <div class="form-text mb-0">We couldn't confirm an active Patreon pledge for your account email. If you believe this is an error, contact us.</div>
+        {% endif %}
+    </div>
+</div>
+{% endif %}
 <form method="post" enctype="multipart/form-data" id="member-form">
     {% csrf_token %}
     <input type="hidden" name="g-recaptcha-response" value="">

--- a/members/tests/test_member_portal.py
+++ b/members/tests/test_member_portal.py
@@ -3,7 +3,8 @@ from unittest.mock import patch
 from wagtail.models import Revision
 
 from django.contrib.auth import get_user_model
-from django.test import TestCase
+from django.core.cache import cache
+from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from blowcomotion.models import (
@@ -163,6 +164,82 @@ class ProfileViewTests(TestCase):
         revision = Revision.objects.for_instance(self.member).first()
         self.assertEqual(revision.user, self.user)
         self.assertIn("Robbie", revision.content.get("preferred_name", ""))
+
+
+class ProfilePatreonStatusTests(TestCase):
+    def setUp(self):
+        self.member = make_member(email="patreontest@example.com")
+        self.user = create_member_user(self.member)
+        self.user.set_password("Pass123!")
+        self.user.save()
+        self.client.login(username="patreontest@example.com", password="Pass123!")
+        self._recaptcha = patch(
+            "members.views._validate_recaptcha", return_value=(True, None)
+        )
+        self._recaptcha.start()
+        cache.clear()
+
+    def tearDown(self):
+        self._recaptcha.stop()
+        cache.clear()
+
+    @override_settings(PATREON_ACCESS_TOKEN=None, PATREON_CAMPAIGN_ID=None)
+    def test_patreon_section_hidden_when_not_configured(self):
+        response = self.client.get(reverse("member-profile"))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Patreon:")
+
+    @override_settings(PATREON_ACCESS_TOKEN="token", PATREON_CAMPAIGN_ID="123")
+    @patch("members.views.check_patreon_membership")
+    def test_patreon_active_status_shown(self, mock_check):
+        mock_check.return_value = {
+            "is_active": True,
+            "pledge_cents": 1000,
+            "last_charge_date": None,
+            "last_charge_status": "Paid",
+            "patron_since": None,
+            "lifetime_cents": 5000,
+        }
+        response = self.client.get(reverse("member-profile"))
+        self.assertContains(response, "Active patron")
+        self.assertContains(response, "$10")
+        mock_check.assert_called_once_with("patreontest@example.com")
+
+    @override_settings(PATREON_ACCESS_TOKEN="token", PATREON_CAMPAIGN_ID="123")
+    @patch("members.views.check_patreon_membership")
+    def test_patreon_inactive_status_shown(self, mock_check):
+        mock_check.return_value = {
+            "is_active": False,
+            "pledge_cents": None,
+            "last_charge_date": None,
+            "last_charge_status": None,
+            "patron_since": None,
+            "lifetime_cents": None,
+        }
+        response = self.client.get(reverse("member-profile"))
+        self.assertContains(response, "Not found or inactive")
+
+    @override_settings(PATREON_ACCESS_TOKEN="token", PATREON_CAMPAIGN_ID="123")
+    @patch("members.views.check_patreon_membership")
+    def test_patreon_unavailable_when_api_errors(self, mock_check):
+        mock_check.return_value = None
+        response = self.client.get(reverse("member-profile"))
+        self.assertContains(response, "status temporarily unavailable")
+
+    @override_settings(PATREON_ACCESS_TOKEN="token", PATREON_CAMPAIGN_ID="123")
+    @patch("members.views.check_patreon_membership")
+    def test_patreon_status_is_cached(self, mock_check):
+        mock_check.return_value = {
+            "is_active": True,
+            "pledge_cents": 1000,
+            "last_charge_date": None,
+            "last_charge_status": "Paid",
+            "patron_since": None,
+            "lifetime_cents": 5000,
+        }
+        self.client.get(reverse("member-profile"))
+        self.client.get(reverse("member-profile"))
+        mock_check.assert_called_once_with("patreontest@example.com")
 
 
 class ConfirmEmailViewTests(TestCase):

--- a/members/views.py
+++ b/members/views.py
@@ -11,6 +11,7 @@ from django.contrib import messages
 from django.contrib.auth import get_user_model, login, views as auth_views
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import PasswordResetForm, SetPasswordForm
+from django.core.cache import cache
 from django.core.management import call_command
 from django.core.paginator import Paginator
 from django.db import transaction
@@ -57,6 +58,48 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 TOKEN_EXPIRY_HOURS = 24
+PATREON_STATUS_CACHE_TTL = 60 * 60  # 1 hour
+
+
+def _patreon_configured():
+    return bool(
+        getattr(settings, "PATREON_ACCESS_TOKEN", None)
+        and getattr(settings, "PATREON_CAMPAIGN_ID", None)
+    )
+
+
+def _get_member_patreon_status(member):
+    """
+    Look up (and cache) the logged-in member's own Patreon pledge status.
+
+    Hits the Patreon API via instruments.patreon.check_patreon_membership,
+    which is a full paginated scan of the campaign's member list — too slow
+    to run on every profile page load, so the result is cached per-email for
+    PATREON_STATUS_CACHE_TTL seconds.
+
+    Returns None if the member has no email or the lookup fails; callers
+    should treat None as "unavailable" rather than erroring. Assumes the
+    caller has already confirmed Patreon is configured.
+    """
+    if not member.email:
+        return None
+
+    cache_key = f"member_patreon_status:{member.email.lower()}"
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    try:
+        result = check_patreon_membership(member.email)
+    except Exception:
+        logger.exception(
+            "profile_view: unexpected error checking Patreon status for member %s", member.pk
+        )
+        return None
+
+    if result is not None:
+        cache.set(cache_key, result, PATREON_STATUS_CACHE_TTL)
+    return result
 
 
 # ── Login ──────────────────────────────────────────────────────────────────────
@@ -225,6 +268,7 @@ def profile_view(request):
     original_email = member.email  # snapshot before form validation mutates member in place
 
     def _profile_context(form):
+        patreon_configured = _patreon_configured()
         return {
             "form": form,
             "member": member,
@@ -236,6 +280,8 @@ def profile_view(request):
             "attendance_this_year": member.attendance_records.filter(
                 date__year=date.today().year
             ).count(),
+            "patreon_configured": patreon_configured,
+            "patreon_status": _get_member_patreon_status(member) if patreon_configured else None,
         }
 
     if request.method == "POST":


### PR DESCRIPTION
## Summary

- Members can now see their own Patreon pledge status on their member portal profile page, mirroring what admins already see on the rental request dashboard (active/inactive, monthly pledge, last charge, patron-since, lifetime support).
- Reuses the existing `instruments.patreon.check_patreon_membership` campaign-member lookup rather than duplicating API logic.
- The lookup is cached per-email for one hour via Django's cache (`django.core.cache`), since the underlying check paginates the full Patreon campaign member list and is too slow to run on every profile page load.
- Members only ever see their own stats — the profile view looks up `request.user.member.email`, never another member's.
- If Patreon isn't configured (e.g. local dev, no `PATREON_ACCESS_TOKEN`/`PATREON_CAMPAIGN_ID`), the section is hidden entirely. If the API call fails, the section shows "status temporarily unavailable" instead of erroring.

Closes #317

## Test plan

- [x] Added `ProfilePatreonStatusTests` in `members/tests/test_member_portal.py` covering: section hidden when not configured, active patron display, inactive/not-found display, API-failure "unavailable" message, and that the result is cached (API mock only called once across two page loads).
- [x] `isort blowcomotion/ members/ instruments/` — clean
- [x] `python manage.py test members instruments` — 330 tests pass
- [x] `python manage.py test` (full suite) — 704 tests pass