### PR TITLE
feat: add gig-o-matic integration test workflow

### DIFF
--- a/.github/workflows/gigo-integration.yml
+++ b/.github/workflows/gigo-integration.yml
@@ -1,0 +1,165 @@
+name: GO3 Integration
+
+# Boots a real Gig-O-Matic (GO3) instance from source and runs our gigs sync
+# against it, as a live integration check on top of the mocked unit tests in
+# gigs/tests/. See https://github.com/Gig-o-Matic/GO3
+#
+# GO3 and blowcomotion.org pin different, incompatible Django versions, so
+# each project gets its own virtualenv inside the job rather than sharing one
+# Python environment.
+
+on:
+  pull_request:
+    branches: [ "development" ]
+  workflow_dispatch:
+
+jobs:
+  gigo-integration:
+    runs-on: ubuntu-latest
+    continue-on-error: false
+
+    steps:
+      - name: Checkout blowcomotion.org
+        uses: actions/checkout@v4
+        with:
+          path: blowcomotion.org
+
+      - name: Checkout Gig-O-Matic GO3
+        uses: actions/checkout@v4
+        with:
+          repository: Gig-o-Matic/GO3
+          path: GO3
+
+      - name: Set up Python for GO3
+        id: py-go3
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install GO3 dependencies
+        working-directory: GO3
+        run: |
+          "${{ steps.py-go3.outputs.python-path }}" -m venv .venv
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install -r requirements.txt
+
+      - name: Set up Python for blowcomotion.org
+        id: py-blowcomotion
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13.1"
+
+      - name: Install blowcomotion.org dependencies
+        working-directory: blowcomotion.org
+        run: |
+          "${{ steps.py-blowcomotion.outputs.python-path }}" -m venv .venv
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install -r requirements.txt
+
+      # GO3's own README documents this exact DATABASE_URL/sqlite invocation
+      # under "Test Suite" as the way its CI runs without a Postgres server.
+      - name: Migrate and seed GO3
+        working-directory: GO3
+        env:
+          DATABASE_URL: "sqlite:///gig-o-matic-ci.sqlite3"
+          SECRET_KEY: "ci-test-secret-key"
+          DEBUG: "True"
+          CAPTCHA_ENABLE: "False"
+        run: |
+          .venv/bin/python manage.py migrate --noinput
+          .venv/bin/python manage.py collectstatic --noinput
+          .venv/bin/python manage.py shell -c "
+          from datetime import timedelta
+
+          from django.utils import timezone
+
+          from band.models import Assoc, Band
+          from band.util import AssocStatusChoices
+          from gig.models import Gig
+          from gig.util import GigStatusChoices
+          from member.models import Member
+
+          member, _ = Member.objects.get_or_create(
+              email='ci-integration@blowcomotion.org',
+              defaults={'username': 'ci-integration'},
+          )
+          member.api_key = 'gh-actions-gigo-ci-key'
+          member.save()
+
+          band, _ = Band.objects.get_or_create(name='Blowcomotion')
+
+          # The gigs API only returns gigs the member has plans for, and GO3
+          # auto-creates plans on gig save for members with a confirmed assoc,
+          # so the assoc must exist before the gig.
+          Assoc.objects.get_or_create(
+              member=member, band=band,
+              defaults={'status': AssocStatusChoices.CONFIRMED},
+          )
+
+          gig, _ = Gig.objects.get_or_create(
+              title='CI Integration Test Gig',
+              band=band,
+              defaults={
+                  'contact': member,
+                  'date': timezone.now() + timedelta(days=30),
+                  'address': '123 Test St, Austin, TX',
+                  'status': GigStatusChoices.CONFIRMED,
+              },
+          )
+
+          print(f'GO3 seeded: band={band.pk}, member={member.pk}, gig={gig.pk}')
+          "
+
+      - name: Start GO3 on port 8001
+        working-directory: GO3
+        env:
+          DATABASE_URL: "sqlite:///gig-o-matic-ci.sqlite3"
+          SECRET_KEY: "ci-test-secret-key"
+          DEBUG: "True"
+          CAPTCHA_ENABLE: "False"
+        run: |
+          nohup .venv/bin/python manage.py runserver 0.0.0.0:8001 > go3-server.log 2>&1 &
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8001/api/docs > /dev/null; then
+              echo "GO3 is up"
+              break
+            fi
+            echo "Waiting for GO3 to start... ($i/30)"
+            sleep 2
+          done
+          curl -sf http://localhost:8001/api/docs > /dev/null || (echo "--- GO3 server log ---"; cat go3-server.log; exit 1)
+
+      - name: Prepare blowcomotion.org database
+        working-directory: blowcomotion.org
+        run: .venv/bin/python manage.py migrate --noinput
+
+      # This is the real integration check: an unmocked call against the
+      # live GO3 instance started above, not the mocked gigs/tests/ suite.
+      - name: Sync gigs against live GO3
+        working-directory: blowcomotion.org
+        env:
+          DJANGO_SETTINGS_MODULE: blowcomotion.settings.ci_gigo
+          GIGO_API_URL: "http://localhost:8001/api"
+          GIGO_API_KEY: "gh-actions-gigo-ci-key"
+          GIGO_BAND_NAME: "Blowcomotion"
+        run: |
+          .venv/bin/python manage.py sync_gigs --verbosity 2 | tee sync_gigs_output.txt
+          if grep -qi "Failed to fetch gigs from API" sync_gigs_output.txt || grep -qi "not configured" sync_gigs_output.txt; then
+            echo "sync_gigs could not reach the live GO3 instance"
+            exit 1
+          fi
+          .venv/bin/python manage.py shell -c "
+          from blowcomotion.models import CachedGig
+          count = CachedGig.objects.count()
+          assert count >= 1, f'Expected at least 1 synced gig in CachedGig, found {count}'
+          print(f'Integration check passed: {count} gig(s) synced from live GO3')
+          "
+
+      - name: Run gigs app test suite
+        working-directory: blowcomotion.org
+        run: .venv/bin/python manage.py test gigs
+
+      - name: Dump GO3 server log on failure
+        if: failure()
+        working-directory: GO3
+        run: cat go3-server.log || true

--- a/.github/workflows/gigo-integration.yml
+++ b/.github/workflows/gigo-integration.yml
@@ -13,6 +13,9 @@ on:
     branches: [ "development" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   gigo-integration:
     runs-on: ubuntu-latest

--- a/blowcomotion/settings/ci_gigo.py
+++ b/blowcomotion/settings/ci_gigo.py
@@ -1,0 +1,17 @@
+"""
+Settings for the Gig-O-Matic (GO3) integration workflow only.
+
+Used by `.github/workflows/gigo-integration.yml`, which boots a real GO3
+instance in the same CI job and points these settings at it, so that
+`sync_gigs` makes a real (unmocked) HTTP call against a live server instead
+of the placeholder `http://localhost:8000/api` in base.py. Not referenced by
+manage.py, dev.py, production.py, or local.py — this is not part of the
+normal dev/prod settings split.
+"""
+import os
+
+from .dev import *
+
+GIGO_API_URL = os.environ.get("GIGO_API_URL", "http://localhost:8001/api")
+GIGO_API_KEY = os.environ.get("GIGO_API_KEY", "")
+GIGO_BAND_NAME = os.environ.get("GIGO_BAND_NAME", "Blowcomotion")


### PR DESCRIPTION
Closes #319

## Summary

Adds a new GitHub Actions workflow, `.github/workflows/gigo-integration.yml`, that runs an end-to-end integration check against a real Gig-O-Matic (GO3) instance, on pull requests to `development` and via manual dispatch. It is a separate workflow from the existing Django CI, so a GO3-side failure never blocks the unit test run.

What the job does:

1. Checks out this repo and `Gig-o-Matic/GO3` side by side. Each project gets its own virtualenv because they pin incompatible Django versions (GO3 pins Django 4.2 on Python 3.12; this repo pins Django 6.0 on Python 3.13).
2. Boots GO3 with sqlite via `DATABASE_URL`, the same mechanism GO3's own README documents for its test suite, avoiding the Postgres container from its docker-compose setup.
3. Seeds GO3 through `manage.py shell`: a member with a known API key, a band named "Blowcomotion", a confirmed band association, and a future-dated confirmed gig. The association must exist before the gig because GO3 auto-creates member plans on gig save, and its gigs API only returns gigs the authenticated member has plans for.
4. Starts GO3 on port 8001 and polls `/api/docs` until it responds.
5. Runs `manage.py sync_gigs` against the live instance using a new settings module, `blowcomotion/settings/ci_gigo.py`, which reads `GIGO_API_URL` / `GIGO_API_KEY` / `GIGO_BAND_NAME` from the environment. This is a real unmocked HTTP round trip: GO3 serializes the seeded gig through its django-ninja API and our sync command parses it and writes a `CachedGig` row. The step then asserts at least one `CachedGig` exists.
6. Runs the `gigs` app test suite.
7. Dumps the GO3 server log if any step fails.

The new settings module is used only by this workflow and is not imported by dev, production, or local settings.

## Test plan

- The workflow triggers on pull requests to `development`, so it runs on this very PR; a green "GO3 Integration" check here is its real validation. GitHub Actions cannot be executed locally, so the GO3 boot, seeding, and live sync steps could only be verified by reading GO3's source (settings, models, API schemas, signals) rather than by running them.
- Validated locally: workflow YAML parses, both embedded Python snippets parse as valid Python after YAML indentation stripping, `blowcomotion.settings.ci_gigo` imports and picks up the env vars, and `python manage.py test gigs` passes (15 tests, OK).
- If the live run surfaces an issue in GO3's boot (for example its firewall middleware or a new required setting), the failure log is captured by the final log-dump step for follow-up.
