### PR TITLE
fix: async form emails and duplicate-submission guard

### DIFF
--- a/blowcomotion/static/js/form.js
+++ b/blowcomotion/static/js/form.js
@@ -1,5 +1,56 @@
 (function ($) {
+    // Forms that go through the shared public-form pipeline, or the member
+    // portal's plain-POST forms.
+    var FORM_SELECTOR = 'form[hx-post*="process-form"], form[action*="process-form"], form#member-form, form[data-recaptcha]';
+
+    // Disable the submit button and relabel it while a submission is in
+    // flight, so a slow response (e.g. a stalled SMTP send) can't be
+    // mistaken for a failed submit and re-clicked, creating duplicates.
+    function markSubmitting($form) {
+        var $btn = $form.find('button[type="submit"]').first();
+        if ($btn.length === 0 || $btn.prop('disabled')) return;
+        $btn.data('original-text', $btn.text());
+        $btn.prop('disabled', true).text('Sending...');
+    }
+
+    // Restore the button so the form can be resubmitted after an error.
+    // Not needed on the plain-POST path: the browser navigates away on submit.
+    function clearSubmitting($form) {
+        var $btn = $form.find('button[type="submit"]').first();
+        if ($btn.length === 0) return;
+        var original = $btn.data('original-text');
+        if (original !== undefined) {
+            $btn.text(original);
+        }
+        $btn.prop('disabled', false);
+    }
+
     $(document).ready(function() {
+        // Plain (non-HTMX) forms: the browser navigates away on submit, so
+        // only disabling is needed. Bound directly (matching how the
+        // reCAPTCHA handler below binds) and registered first, so it runs
+        // before that handler's `return false` can stop propagation.
+        $(FORM_SELECTOR).not('[hx-post]').on('submit', function() {
+            markSubmitting($(this));
+        });
+
+        // HTMX forms: htmx does not disable buttons on its own. Disable as
+        // soon as the request starts and re-enable once it completes, in
+        // case the response leaves the form in place (e.g. a validation error).
+        document.body.addEventListener('htmx:beforeRequest', function(event) {
+            var form = event.detail.elt;
+            if (form.tagName !== 'FORM') form = form.closest('form');
+            if (!form || !$(form).is(FORM_SELECTOR)) return;
+            markSubmitting($(form));
+        });
+
+        document.body.addEventListener('htmx:afterRequest', function(event) {
+            var form = event.detail.elt;
+            if (form.tagName !== 'FORM') form = form.closest('form');
+            if (!form || !$(form).is(FORM_SELECTOR)) return;
+            clearSubmitting($(form));
+        });
+
         // reCAPTCHA disclosure notice (required when hiding the badge)
         $('form[hx-post*="process-form"], form[action*="process-form"], form#member-form, form[data-recaptcha]').each(function() {
             var $form = $(this);

--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -23,6 +23,7 @@ from blowcomotion.models import (
     SiteSettings,
 )
 from members.auth import (
+    _dispatch_email,
     _MemberEmail,
     create_member_user,
     send_member_signup_welcome_email,
@@ -120,10 +121,15 @@ def _validate_recaptcha(request):
 
 
 def _send_form_email(subject, message, recipient_list):
-    """Send email for form submission."""
-    _MemberEmail(
+    """Send email for form submission.
+
+    Sent from a background thread (see _dispatch_email) so a slow SMTP
+    server can't stall the form-submission response.
+    """
+    email_message = _MemberEmail(
         subject=subject, body=message, from_email=settings.FROM_EMAIL, to=recipient_list
-    ).send(fail_silently=False)
+    )
+    _dispatch_email(email_message, fail_silently=False, background=True)
 
 
 def _create_email_message(form_type, name, email, **kwargs):
@@ -288,7 +294,9 @@ def _process_member_signup(request, form_data):
         if member.email:
             try:
                 create_member_user(member)
-                send_member_signup_welcome_email(member, f"{request.scheme}://{request.get_host()}")
+                send_member_signup_welcome_email(
+                    member, f"{request.scheme}://{request.get_host()}", background=True
+                )
                 logger.info(f"Sent signup welcome email to new member {member.pk}")
             except Exception as e:
                 logger.warning(f"Could not send welcome email to new member {member.pk}: {e}")

--- a/members/auth.py
+++ b/members/auth.py
@@ -1,5 +1,6 @@
 import email.policy
 import logging
+import threading
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -34,13 +35,42 @@ class _MemberEmail(EmailMessage):
         return result
 
 
-def _send_mail(subject, body, from_email, recipient):
-    _MemberEmail(
+def _dispatch_email(email_message, fail_silently=False, background=False):
+    """Send an EmailMessage, optionally off of the request/command thread.
+
+    Runs synchronously whenever the locmem test backend is active, so tests
+    can assert on mail.outbox immediately after the request/command returns.
+    Otherwise, when background=True, sends from a daemon thread so a slow
+    SMTP server can't stall the caller (e.g. a public form submission).
+
+    background should only be True for request-serving code paths: a daemon
+    thread is killed the instant its process exits, so one-shot management
+    commands must keep sending synchronously to avoid dropping mail.
+    """
+    if not background or settings.EMAIL_BACKEND == "django.core.mail.backends.locmem.EmailBackend":
+        email_message.send(fail_silently=fail_silently)
+        return
+
+    def _send():
+        try:
+            email_message.send(fail_silently=False)
+        except Exception:
+            logger.exception(
+                "Background email send failed (subject=%r, to=%r)",
+                email_message.subject, email_message.to,
+            )
+
+    threading.Thread(target=_send, daemon=True).start()
+
+
+def _send_mail(subject, body, from_email, recipient, background=False):
+    email_message = _MemberEmail(
         subject=subject,
         body=body,
         from_email=from_email,
         to=[recipient],
-    ).send(fail_silently=False)
+    )
+    _dispatch_email(email_message, fail_silently=False, background=background)
 
 
 def needs_set_password(member):
@@ -124,8 +154,13 @@ def send_email_change_confirmation(member, new_email, base_url):
     logger.info(f"Sent email-change confirmation to {new_email} for member {member.pk}")
 
 
-def send_member_signup_welcome_email(member, base_url):
-    """Create a PasswordSetToken and email the new member a welcome with both next steps."""
+def send_member_signup_welcome_email(member, base_url, background=False):
+    """Create a PasswordSetToken and email the new member a welcome with both next steps.
+
+    background=True sends the email from a daemon thread so a slow SMTP
+    server doesn't stall the signup request; pass it only from request-serving
+    call sites (see _dispatch_email).
+    """
     _supersede_set_password_tokens(member)
     token = PasswordSetToken.objects.create(member=member)
     set_password_url = f"{base_url}/member/set-password/{token.uuid}/"
@@ -138,7 +173,7 @@ def send_member_signup_welcome_email(member, base_url):
             "get_access_url": f"{base_url}{reverse('member-get-access')}",
         },
     )
-    _send_mail(subject, message, settings.FROM_EMAIL, member.email)
+    _send_mail(subject, message, settings.FROM_EMAIL, member.email, background=background)
     logger.info(f"Sent signup welcome email to member {member.pk} ({member.email})")
 
 


### PR DESCRIPTION
Closes #176

## Summary

During in-person signup sessions, the member signup form required 2-3 submissions to reach the Thank You screen, creating duplicate Member entries. Root cause: `process_form()` sent the admin notification email and the new-member welcome email synchronously over SMTP inside the request/response cycle, so a slow SMTP connection stalled the response and users resubmitted before seeing feedback.

This PR fixes both the server-side blocking and the client-side symptom:

- `members/auth.py`: adds `_dispatch_email()`, a small helper that sends an `EmailMessage` from a daemon thread when `background=True` is requested, and synchronously otherwise. It always runs synchronously when the locmem test backend is active, so `mail.outbox` assertions in existing tests are unaffected. `background` defaults to `False` everywhere, so management commands (`nag_instrument_renters`, `send_attendance_report`, birthday commands, `invite_members`) and other non-web callers keep sending synchronously — a daemon thread is killed the instant a one-shot command's process exits, so backgrounding those would silently drop mail.
- `blowcomotion/views.py`: `_send_form_email()` (the single path shared by all six public form types routed through `process_form()`: contact, join band, booking, donate, feedback, member signup) and the member-signup welcome email now pass `background=True`, so neither blocks the request.
- The `_MemberEmail.send()` FORM_TEST_EMAIL bcc/copy behavior is untouched — it still runs inside `.send()`, which the background thread also calls.
- `blowcomotion/static/js/form.js`: disables the submit button and relabels it ("Sending...") once a submission starts, covering both the `hx-post` path (via `htmx:beforeRequest`/`htmx:afterRequest`, since htmx does not disable buttons on its own) and the plain-POST member-portal forms. No new inline per-template handlers were added, matching the existing single-handler convention for these forms. Verified against the vendored htmx source that form values (e.g. the hidden `form_type` input) are serialized before `htmx:beforeRequest` fires, so disabling the button in that handler does not strip any submitted fields.

## Test plan

- [x] `python manage.py test` — 699 tests, all passing
- [x] `isort --check-only blowcomotion/ members/` — clean
- [ ] Manual: submit the member signup form on a slow/console-backend dev server and confirm the page responds immediately (button shows "Sending..." then the Thank You screen), with the welcome and admin notification emails both appearing in the console shortly after
- [ ] Manual: submit each of the other public forms (contact, join band, booking, donate, feedback) and confirm `form_type` and all other fields still arrive at `/process-form/` and the email lands in the console backend
- [ ] Manual: double-click a form's submit button in quick succession and confirm the button disables after the first click, preventing a second POST
- [ ] Manual: run `nag_instrument_renters --dry-run` (or similar management command) against a real SMTP backend and confirm it still completes with mail sent before the process exits, unaffected by this change