### PR TITLE
fix: query member email through user relation in login link request

### DIFF
--- a/members/views.py
+++ b/members/views.py
@@ -150,7 +150,7 @@ def login_link_request(request):
     email = (request.POST.get("email") or "").strip()
     if email:
         try:
-            member = Member.objects.get(email__iexact=email, is_active=True)
+            member = Member.objects.get(user__email__iexact=email, is_active=True)
         except (Member.DoesNotExist, Member.MultipleObjectsReturned):
             logger.info("Login link requested for unknown or ambiguous email")
         else:


### PR DESCRIPTION
Fixes the Django CI failure on development introduced by the interaction of PR #329 and PR #335.

PR #329's login_link_request was written against the old Member model and queries Member.objects.get(email__iexact=...). PR #335 moved email off Member onto the linked auth User, so that lookup now raises FieldError: Cannot resolve keyword 'email' into field, returning a 500 from /member/login/link/. The two PRs merged without a git conflict, so the break only surfaced in CI after both landed.

One-line fix: email__iexact -> user__email__iexact, matching the two other lookups in the same file that #335 already converted.

Full test suite passes locally: 743 tests, OK.