### PR TITLE
feat: add admin tool usage dashboard

### DIFF
--- a/blowcomotion/templates/wagtailadmin/admin_tool_usage_dashboard.html
+++ b/blowcomotion/templates/wagtailadmin/admin_tool_usage_dashboard.html
@@ -1,0 +1,85 @@
+{% extends "wagtailadmin/base.html" %}
+{% block titletag %}Admin Tool Usage{% endblock %}
+{% block content %}
+<div class="nice-padding">
+    <h1>Admin Tool Usage</h1>
+    <p>Which admin tools get used, by whom, and how often. Events are recorded automatically on every admin page view and button click (see issue #311).</p>
+
+    <div style="margin-bottom:1.5rem;display:flex;gap:0.5rem;align-items:center;">
+        <span>Period:</span>
+        {% for option in period_options %}
+        <a href="?days={{ option }}" class="button button-small {% if option != days %}button-secondary{% endif %}">Last {{ option }} days</a>
+        {% endfor %}
+        <span style="color:var(--w-color-text-meta);">{{ total_events }} event{{ total_events|pluralize }} in period</span>
+    </div>
+
+    {% if total_events %}
+    <h2>Usage over time</h2>
+    <div style="display:flex;align-items:flex-end;gap:2px;height:120px;max-width:800px;border-bottom:1px solid var(--w-color-border-furniture);margin-bottom:0.25rem;">
+        {% for d in usage_by_day %}
+        <div title="{{ d.day|date:'M j' }}: {{ d.count }} event{{ d.count|pluralize }}"
+             style="flex:1;min-width:2px;background:var(--w-color-secondary);border-radius:2px 2px 0 0;height:{{ d.pct }}%;"></div>
+        {% endfor %}
+    </div>
+    <div style="display:flex;justify-content:space-between;max-width:800px;color:var(--w-color-text-meta);font-size:0.85em;margin-bottom:1.5rem;">
+        <span>{{ usage_by_day.0.day|date:"M j" }}</span>
+        <span>{% with last_day=usage_by_day|last %}{{ last_day.day|date:"M j" }}{% endwith %}</span>
+    </div>
+
+    <h2>Most-used tools</h2>
+    <table class="listing" style="max-width:800px;">
+        <thead>
+            <tr><th>Tool</th><th style="width:6em;">Events</th><th style="width:40%;"></th></tr>
+        </thead>
+        <tbody>
+            {% for t in top_tools %}
+            <tr>
+                <td>{{ t.tool }}</td>
+                <td>{{ t.count }}</td>
+                <td><div style="background:var(--w-color-secondary);border-radius:2px;height:0.75rem;width:{{ t.pct }}%;"></div></td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    <h2>Per-user breakdown</h2>
+    <table class="listing" style="max-width:800px;">
+        <thead>
+            <tr><th>User</th><th style="width:6em;">Events</th><th>Top tools (events)</th></tr>
+        </thead>
+        <tbody>
+            {% for u in per_user %}
+            <tr>
+                <td>{{ u.user }}</td>
+                <td>{{ u.count }}</td>
+                <td>{{ u.top_tools|join:", " }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    <h2>Most-clicked actions</h2>
+    <p style="color:var(--w-color-text-meta);">Button and link clicks within tools; plain page views are excluded.</p>
+    {% if top_actions %}
+    <table class="listing" style="max-width:800px;">
+        <thead>
+            <tr><th>Tool</th><th>Action</th><th style="width:6em;">Clicks</th></tr>
+        </thead>
+        <tbody>
+            {% for a in top_actions %}
+            <tr>
+                <td>{{ a.tool }}</td>
+                <td>{{ a.action }}</td>
+                <td>{{ a.count }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p>No clicks recorded in this period.</p>
+    {% endif %}
+    {% else %}
+    <p>No usage recorded in this period.</p>
+    {% endif %}
+</div>
+{% endblock %}

--- a/blowcomotion/tests/test_admin_tool_usage.py
+++ b/blowcomotion/tests/test_admin_tool_usage.py
@@ -1,12 +1,15 @@
 """
-Tests for the admin tool usage tracking endpoint (issue #311).
+Tests for the admin tool usage tracking endpoint (issue #311) and the
+usage dashboard built on top of it (issue #333).
 """
 
 import json
+from datetime import timedelta
 
 from django.contrib.auth import get_user_model
 from django.middleware.csrf import get_token
 from django.test import Client, RequestFactory, TestCase
+from django.utils import timezone
 
 from blowcomotion.models import AdminToolUsage
 
@@ -117,3 +120,82 @@ class AdminToolUsageViewTests(TestCase):
         )
         self.assertEqual(response.status_code, 204)
         self.assertEqual(AdminToolUsage.objects.count(), 1)
+
+
+class AdminToolUsageDashboardTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.url = '/admin/tool-usage/'
+
+        self.superuser = User.objects.create_superuser(
+            username='super',
+            password='testpass',
+            first_name='Sue',
+            last_name='Per',
+        )
+        self.staff_user = User.objects.create_user(
+            username='staff',
+            password='testpass',
+            is_staff=True,
+        )
+
+    def test_requires_permission(self):
+        self.client.login(username='staff', password='testpass')
+        response = self.client.get(self.url)
+        self.assertNotEqual(response.status_code, 200)
+
+    def test_anonymous_is_redirected_to_login(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 302)
+
+    def test_dashboard_aggregates_usage(self):
+        AdminToolUsage.objects.create(user=self.superuser, tool='/admin/pages/')
+        AdminToolUsage.objects.create(user=self.superuser, tool='/admin/pages/')
+        AdminToolUsage.objects.create(user=self.superuser, tool='/admin/images/', action='upload-button')
+        AdminToolUsage.objects.create(user=self.staff_user, tool='/admin/images/')
+        # Backdate one record outside the default 30-day window; it must
+        # not be counted (auto_now_add means we update after create).
+        old = AdminToolUsage.objects.create(user=self.staff_user, tool='/admin/old-tool/')
+        AdminToolUsage.objects.filter(pk=old.pk).update(
+            timestamp=timezone.now() - timedelta(days=45)
+        )
+
+        self.client.login(username='super', password='testpass')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(response.context['days'], 30)
+        self.assertEqual(response.context['total_events'], 4)
+
+        top_tools = response.context['top_tools']
+        self.assertEqual(top_tools[0]['tool'], '/admin/pages/')
+        self.assertEqual(top_tools[0]['count'], 2)
+        self.assertEqual(top_tools[0]['pct'], 100)
+        self.assertNotIn('/admin/old-tool/', [t['tool'] for t in top_tools])
+
+        per_user = response.context['per_user']
+        self.assertEqual(per_user[0]['user'], 'Sue Per')
+        self.assertEqual(per_user[0]['count'], 3)
+        self.assertEqual(per_user[1]['user'], 'staff')
+        self.assertEqual(per_user[1]['count'], 1)
+
+        top_actions = response.context['top_actions']
+        self.assertEqual(len(top_actions), 1)
+        self.assertEqual(top_actions[0]['action'], 'upload-button')
+
+        usage_by_day = response.context['usage_by_day']
+        self.assertEqual(len(usage_by_day), 30)
+        self.assertEqual(usage_by_day[-1]['day'], timezone.localdate())
+        self.assertEqual(usage_by_day[-1]['count'], 4)
+
+    def test_invalid_days_falls_back_to_30(self):
+        self.client.login(username='super', password='testpass')
+        for bad in ('999', 'abc', '-7'):
+            response = self.client.get(self.url, {'days': bad})
+            self.assertEqual(response.context['days'], 30)
+
+    def test_valid_period_is_honoured(self):
+        self.client.login(username='super', password='testpass')
+        response = self.client.get(self.url, {'days': '7'})
+        self.assertEqual(response.context['days'], 7)
+        self.assertEqual(len(response.context['usage_by_day']), 7)

--- a/blowcomotion/tests/test_admin_tool_usage.py
+++ b/blowcomotion/tests/test_admin_tool_usage.py
@@ -7,6 +7,7 @@ import json
 from datetime import timedelta
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.middleware.csrf import get_token
 from django.test import Client, RequestFactory, TestCase
 from django.utils import timezone
@@ -21,10 +22,18 @@ class AdminToolUsageViewTests(TestCase):
         self.client = Client()
         self.url = '/admin-tool-usage/'
 
-        self.staff_user = User.objects.create_user(
-            username='staff',
+        # Real Wagtail admin users are typically is_staff=False with the
+        # wagtailadmin.access_admin permission (Wagtail never sets is_staff);
+        # the view must accept them — see the prod bug this shape caught.
+        self.admin_user = User.objects.create_user(
+            username='wagtailadmin',
             password='testpass',
-            is_staff=True,
+        )
+        self.admin_user.user_permissions.add(
+            Permission.objects.get(
+                codename='access_admin',
+                content_type__app_label='wagtailadmin',
+            )
         )
         self.regular_user = User.objects.create_user(
             username='regular',
@@ -32,8 +41,8 @@ class AdminToolUsageViewTests(TestCase):
             is_staff=False,
         )
 
-    def test_staff_post_creates_record(self):
-        self.client.login(username='staff', password='testpass')
+    def test_admin_user_post_creates_record(self):
+        self.client.login(username='wagtailadmin', password='testpass')
         response = self.client.post(
             self.url,
             data=json.dumps({'tool': '/admin/images/', 'action': 'upload-button'}),
@@ -42,12 +51,12 @@ class AdminToolUsageViewTests(TestCase):
         self.assertEqual(response.status_code, 204)
         self.assertEqual(AdminToolUsage.objects.count(), 1)
         record = AdminToolUsage.objects.first()
-        self.assertEqual(record.user, self.staff_user)
+        self.assertEqual(record.user, self.admin_user)
         self.assertEqual(record.tool, '/admin/images/')
         self.assertEqual(record.action, 'upload-button')
 
-    def test_staff_post_without_action_creates_page_view_record(self):
-        self.client.login(username='staff', password='testpass')
+    def test_admin_user_post_without_action_creates_page_view_record(self):
+        self.client.login(username='wagtailadmin', password='testpass')
         response = self.client.post(
             self.url,
             data=json.dumps({'tool': '/admin/pages/'}),
@@ -59,7 +68,7 @@ class AdminToolUsageViewTests(TestCase):
         self.assertEqual(record.action, '')
 
     def test_missing_tool_returns_400(self):
-        self.client.login(username='staff', password='testpass')
+        self.client.login(username='wagtailadmin', password='testpass')
         response = self.client.post(
             self.url,
             data=json.dumps({'action': 'click'}),
@@ -77,7 +86,7 @@ class AdminToolUsageViewTests(TestCase):
         self.assertEqual(response.status_code, 403)
         self.assertEqual(AdminToolUsage.objects.count(), 0)
 
-    def test_non_staff_post_is_rejected(self):
+    def test_user_without_admin_access_is_rejected(self):
         self.client.login(username='regular', password='testpass')
         response = self.client.post(
             self.url,
@@ -87,8 +96,23 @@ class AdminToolUsageViewTests(TestCase):
         self.assertEqual(response.status_code, 403)
         self.assertEqual(AdminToolUsage.objects.count(), 0)
 
+    def test_is_staff_alone_is_not_enough(self):
+        # is_staff is a Django-admin concept and does not grant Wagtail admin
+        # access; the view keys off wagtailadmin.access_admin instead.
+        User.objects.create_user(
+            username='djangostaff', password='testpass', is_staff=True,
+        )
+        self.client.login(username='djangostaff', password='testpass')
+        response = self.client.post(
+            self.url,
+            data=json.dumps({'tool': '/admin/images/'}),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(AdminToolUsage.objects.count(), 0)
+
     def test_get_is_rejected(self):
-        self.client.login(username='staff', password='testpass')
+        self.client.login(username='wagtailadmin', password='testpass')
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 405)
 
@@ -101,7 +125,7 @@ class AdminToolUsageViewTests(TestCase):
         regression here (e.g. reading request.POST before request.body).
         """
         csrf_client = Client(enforce_csrf_checks=True)
-        csrf_client.force_login(self.staff_user)
+        csrf_client.force_login(self.admin_user)
 
         # Populate the csrftoken cookie the same way a real browser session
         # would: any admin page rendering {% csrf_token %} calls get_token()

--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -796,7 +796,9 @@ def log_admin_tool_usage(request):
     X-CSRFToken header or a csrfmiddlewaretoken field, depending on how it
     sends the request.
     """
-    if not (request.user.is_authenticated and request.user.is_staff):
+    # Wagtail admin users are not necessarily is_staff (Wagtail gates on the
+    # access_admin permission), so check that, like fetch_embed_data does.
+    if not (request.user.is_authenticated and request.user.has_perm('wagtailadmin.access_admin')):
         return JsonResponse({'error': 'Authentication required'}, status=403)
 
     data = {}

--- a/blowcomotion/views.py
+++ b/blowcomotion/views.py
@@ -1,16 +1,19 @@
 import json
 import logging
-from collections import defaultdict
-from datetime import date, datetime
+from collections import Counter, defaultdict
+from datetime import date, datetime, timedelta
 from io import StringIO
 
 import requests
 
 from django.conf import settings
+from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.forms import AuthenticationForm, UserCreationForm
 from django.core.management import call_command
+from django.db.models import Count
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
+from django.utils import timezone
 from django.views.decorators.http import require_http_methods
 
 from blowcomotion.models import (
@@ -813,3 +816,89 @@ def log_admin_tool_usage(request):
 
     AdminToolUsage.objects.create(user=request.user, tool=tool, action=action)
     return HttpResponse(status=204)
+
+
+ADMIN_TOOL_USAGE_PERIODS = (7, 30, 90)
+
+
+@permission_required('blowcomotion.view_admintoolusage', raise_exception=True)
+def admin_tool_usage_dashboard(request):
+    """
+    Wagtail admin dashboard visualizing AdminToolUsage records (issue #333):
+    most-used tools, usage per day, per-user breakdown, and most-clicked
+    actions, over a selectable 7/30/90-day period.
+    """
+    try:
+        days = int(request.GET.get('days', 30))
+    except (TypeError, ValueError):
+        days = 30
+    if days not in ADMIN_TOOL_USAGE_PERIODS:
+        days = 30
+
+    today = timezone.localdate()
+    start_date = today - timedelta(days=days - 1)
+    since = timezone.make_aware(datetime.combine(start_date, datetime.min.time()))
+    records = AdminToolUsage.objects.filter(timestamp__gte=since)
+
+    # Bucketed in Python rather than TruncDate: on MySQL (production) that
+    # compiles to CONVERT_TZ, which silently returns NULL unless the server's
+    # timezone tables are loaded. Volume is small (admin clicks only).
+    per_day_counts = Counter(
+        timezone.localtime(ts).date()
+        for ts in records.values_list('timestamp', flat=True)
+    )
+
+    top_tools = list(
+        records.values('tool').annotate(count=Count('id')).order_by('-count')[:20]
+    )
+    max_tool_count = top_tools[0]['count'] if top_tools else 0
+    for row in top_tools:
+        row['pct'] = round(row['count'] / max_tool_count * 100) if max_tool_count else 0
+
+    max_day_count = max(per_day_counts.values(), default=0)
+    usage_by_day = []
+    for i in range(days):
+        day = start_date + timedelta(days=i)
+        count = per_day_counts.get(day, 0)
+        usage_by_day.append({
+            'day': day,
+            'count': count,
+            'pct': round(count / max_day_count * 100) if max_day_count else 0,
+        })
+
+    # Per-user totals with each user's top 3 tools, from one grouped query.
+    user_tool_counts = (
+        records.values('user__username', 'user__first_name', 'user__last_name', 'tool')
+        .annotate(count=Count('id'))
+        .order_by('-count')
+    )
+    per_user = {}
+    for row in user_tool_counts:
+        name = f"{row['user__first_name'] or ''} {row['user__last_name'] or ''}".strip()
+        label = name or row['user__username'] or 'deleted user'
+        entry = per_user.setdefault(label, {'user': label, 'count': 0, 'top_tools': []})
+        entry['count'] += row['count']
+        if len(entry['top_tools']) < 3:
+            entry['top_tools'].append(f"{row['tool']} ({row['count']})")
+    per_user = sorted(per_user.values(), key=lambda e: e['count'], reverse=True)
+
+    top_actions = list(
+        records.exclude(action='')
+        .values('tool', 'action')
+        .annotate(count=Count('id'))
+        .order_by('-count')[:20]
+    )
+
+    return render(
+        request,
+        'wagtailadmin/admin_tool_usage_dashboard.html',
+        {
+            'days': days,
+            'period_options': ADMIN_TOOL_USAGE_PERIODS,
+            'total_events': sum(per_day_counts.values()),
+            'top_tools': top_tools,
+            'usage_by_day': usage_by_day,
+            'per_user': per_user,
+            'top_actions': top_actions,
+        },
+    )

--- a/blowcomotion/wagtail_hooks.py
+++ b/blowcomotion/wagtail_hooks.py
@@ -10,7 +10,7 @@ from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
 from attendance.views import export_attendance_csv
-from blowcomotion.views import dump_data, fetch_embed_data
+from blowcomotion.views import admin_tool_usage_dashboard, dump_data, fetch_embed_data
 from charts.views import export_charts_csv
 from gigs.views import sync_gigs_admin
 from instruments.views import (
@@ -85,6 +85,7 @@ def register_admin_urls():
     """
     return [
         path("dump_data/", dump_data, name="dump_data"),
+        path("tool-usage/", admin_tool_usage_dashboard, name="admin_tool_usage_dashboard"),
         path("sync_gigs/", sync_gigs_admin, name="sync_gigs"),
         path("export_members/", export_members_csv, name="export_members"),
         path("export_attendance/", export_attendance_csv, name="export_attendance"),
@@ -135,6 +136,7 @@ EXPORTS_PERMISSIONS = ['blowcomotion.access_dev_tools', 'blowcomotion.access_rea
 # fall back to "show if any child is visible").
 UTILITIES_PERMISSIONS = EXPORTS_PERMISSIONS + [
     'blowcomotion.change_cachedgig',  # Sync Gigs
+    'blowcomotion.view_admintoolusage',  # Tool Usage dashboard
 ]
 
 
@@ -161,6 +163,8 @@ def register_management_menu_item():
                                    permission=EXPORTS_PERMISSIONS),
         PermissionMenuItem('Sync Gigs', reverse('sync_gigs'), icon_name='cog',
                             permission='blowcomotion.change_cachedgig'),
+        PermissionMenuItem('Tool Usage', reverse('admin_tool_usage_dashboard'), icon_name='cogs',
+                            permission='blowcomotion.view_admintoolusage'),
     ])
     return PermissionSubmenuMenuItem(
         'Utilities', submenu, icon_name='cogs', order=10000,


### PR DESCRIPTION
Closes #333

## Summary
- New Wagtail admin dashboard at `/admin/tool-usage/` visualizing the `AdminToolUsage` records collected since #311 (PR #331)
- Most-used tools ranked with inline bars, usage-per-day column chart (pure CSS, no chart dependency), per-user breakdown with each user's top 3 tools, and most-clicked actions table
- Selectable period: last 7 / 30 / 90 days (invalid values fall back to 30)
- Linked from the Utilities admin menu; gated by the `blowcomotion.view_admintoolusage` permission (superusers have it implicitly)
- All custom styling uses `var(--w-color-*)` CSS variables so dark mode works
- Per-day bucketing is done in Python rather than `TruncDate` because on MySQL (production) `TruncDate` compiles to `CONVERT_TZ`, which silently returns NULL when the server's timezone tables are not loaded; volume is small (admin clicks only)

Deferred from the issue: the data retention / pruning management command, which the issue itself defers until volume is known.

## Test plan
- [ ] `python manage.py test blowcomotion.tests.test_admin_tool_usage` (12 tests: endpoint + dashboard aggregation, period validation, permission gating)
- [ ] Log into the Wagtail admin as a superuser, open Utilities > Tool Usage, and confirm the chart and tables render with real tracked data
- [ ] Switch between the 7/30/90-day period buttons and confirm counts change
- [ ] Toggle admin dark mode and confirm the chart bars and meta text remain legible
- [ ] Confirm a non-superuser without `view_admintoolusage` cannot open the page and does not see the menu item