### PR TITLE
fix: add img-fluid class to rich text editor images

### DIFF
--- a/blowcomotion/tests/test_richtext_image_formats.py
+++ b/blowcomotion/tests/test_richtext_image_formats.py
@@ -1,0 +1,12 @@
+from wagtail.images.formats import get_image_format
+
+from django.test import TestCase
+
+import blowcomotion.wagtail_hooks  # noqa: F401  ensures format overrides are registered
+
+
+class RichTextImageFormatTests(TestCase):
+    def test_default_image_formats_include_img_fluid(self):
+        for name in ("fullwidth", "left", "right"):
+            classname = get_image_format(name).classname
+            self.assertIn("img-fluid", classname.split())

--- a/blowcomotion/wagtail_hooks.py
+++ b/blowcomotion/wagtail_hooks.py
@@ -1,6 +1,12 @@
 from wagtail import hooks
 from wagtail.admin.menu import Menu, MenuItem, SubmenuMenuItem
 from wagtail.admin.ui.components import Component
+from wagtail.images.formats import (
+    FORMATS_BY_NAME,
+    Format,
+    register_image_format,
+    unregister_image_format,
+)
 from wagtail.snippets.models import register_snippet
 
 from django.conf import settings as django_settings
@@ -46,6 +52,23 @@ register_snippet(BandViewSetGroup)
 register_snippet(FormsViewSetGroup)
 register_snippet(SyncViewSetGroup)
 register_snippet(AdminToolUsageViewSet)
+
+
+def _add_img_fluid_to_richtext_image_formats():
+    """
+    Wagtail's built-in rich text image formats (full width/left/right) don't
+    scale on mobile by default. Append the site's "img-fluid" class so every
+    image inserted through a RichTextField/RichTextBlock scales responsively,
+    matching how images are already rendered everywhere else on the site.
+    """
+    for name, fmt in list(FORMATS_BY_NAME.items()):
+        unregister_image_format(name)
+        register_image_format(
+            Format(fmt.name, fmt.label, f"{fmt.classname} img-fluid", fmt.filter_spec)
+        )
+
+
+_add_img_fluid_to_richtext_image_formats()
 
 
 def _permission_granted(user, permission):


### PR DESCRIPTION
## Summary
- Images inserted through a RichTextField/RichTextBlock in the CMS editor (full width, left-aligned, right-aligned) rendered without a responsive class and didn't scale down on mobile.
- Overrides Wagtail's three default rich text image formats to append `img-fluid` to their classname. This is a single systemic fix: all rich text front-end image rendering routes through `Format.image_to_html`, so it applies everywhere a RichTextField/RichTextBlock is used, without needing to touch individual templates.
- Matches the `img-fluid` convention already used by every other image-rendering block on the site (`image_block.html`, `full_width_image_block.html`, header logo, etc.).

## Test plan
- [x] `python manage.py test` — full suite passes (752 tests)
- [x] Added `blowcomotion/tests/test_richtext_image_formats.py` asserting the `fullwidth`/`left`/`right` image formats include `img-fluid`
- [x] `isort --check-only` clean on changed files