### PR TITLE
feat: add column sorting to rental requests dashboard

### DIFF
--- a/blowcomotion/templates/wagtailadmin/rental_requests_dashboard.html
+++ b/blowcomotion/templates/wagtailadmin/rental_requests_dashboard.html
@@ -71,15 +71,9 @@
     <table class="listing">
         <thead>
             <tr>
-                <th>Member</th>
-                <th>1st Choice</th>
-                <th>Submitted</th>
-                <th>Status</th>
-                <th>Patreon</th>
-                <th>Pledge/mo</th>
-                <th>Last charge</th>
-                <th>Patron since</th>
-                <th>Lifetime</th>
+                {% for col in sort_columns %}
+                <th><a href="{{ col.url }}" title="Sort by {{ col.label }}">{{ col.label }}{% if col.arrow %} <span aria-hidden="true">{{ col.arrow }}</span>{% endif %}</a></th>
+                {% endfor %}
                 <th></th>
             </tr>
         </thead>

--- a/instruments/tests/test_instrument_rental.py
+++ b/instruments/tests/test_instrument_rental.py
@@ -474,6 +474,27 @@ class RentalRequestsAdminViewTest(TestCase):
         response = self.client.get(reverse("rental_requests_dashboard"))
         self.assertEqual(response.status_code, 200)
 
+    def test_dashboard_sorting(self):
+        other = InstrumentRentalRequestSubmission.objects.create(
+            name="Aaron Aardvark",
+            email="aaron@example.com",
+            instrument=self.instrument,
+            status=InstrumentRentalRequestSubmission.STATUS_APPROVED,
+            policy_acknowledged=True,
+        )
+
+        def names(query):
+            response = self.client.get(reverse("rental_requests_dashboard") + query)
+            self.assertEqual(response.status_code, 200)
+            return [s.name for s in response.context["submissions"]]
+
+        # default: pending first regardless of name
+        self.assertEqual(names("")[0], self.submission.name)
+        self.assertEqual(names("?sort=member"), [other.name, self.submission.name])
+        self.assertEqual(names("?sort=-member"), [self.submission.name, other.name])
+        # unknown sort keys fall back to the default ordering, not a 500
+        self.assertEqual(names("?sort=bogus")[0], self.submission.name)
+
     def test_review_get_returns_200(self):
         response = self.client.get(reverse("rental_request_review", args=[self.submission.pk]))
         self.assertEqual(response.status_code, 200)

--- a/instruments/views.py
+++ b/instruments/views.py
@@ -295,6 +295,31 @@ def _send_rental_returned_email(request, submission, condition_notes):
         ).send(fail_silently=True)
 
 
+# Sortable dashboard columns: URL key -> model field, and the header labels in table order.
+RENTAL_DASHBOARD_SORTS = {
+    "member": "name",
+    "instrument": "instrument__name",
+    "submitted": "date_submitted",
+    "status": "status",
+    "patreon": "patreon_validated",
+    "pledge": "patreon_pledge_cents",
+    "last_charge": "patreon_last_charge_date",
+    "patron_since": "patreon_patron_since",
+    "lifetime": "patreon_lifetime_cents",
+}
+RENTAL_DASHBOARD_COLUMNS = [
+    ("member", "Member"),
+    ("instrument", "1st Choice"),
+    ("submitted", "Submitted"),
+    ("status", "Status"),
+    ("patreon", "Patreon"),
+    ("pledge", "Pledge/mo"),
+    ("last_charge", "Last charge"),
+    ("patron_since", "Patron since"),
+    ("lifetime", "Lifetime"),
+]
+
+
 @permission_required('blowcomotion.change_libraryinstrument', raise_exception=True)
 def rental_requests_dashboard(request):
     import re as _re
@@ -516,6 +541,24 @@ def rental_requests_dashboard(request):
             messages.success(request, f"Deleted denied rental request from {name}.")
             return redirect("rental_requests_dashboard")
 
+    sort = request.GET.get("sort", "")
+    sort_field = RENTAL_DASHBOARD_SORTS.get(sort.lstrip("-"))
+    if sort_field:
+        order_by = ["-" + sort_field if sort.startswith("-") else sort_field, "-date_submitted"]
+    else:
+        sort = ""
+        order_by = ["status_order", "-date_submitted"]
+
+    sort_columns = [
+        {
+            "label": label,
+            # clicking the column you're already sorting ascending flips it to descending
+            "url": f"?sort={'-' if sort == key else ''}{key}",
+            "arrow": "▲" if sort == key else ("▼" if sort == "-" + key else ""),
+        }
+        for key, label in RENTAL_DASHBOARD_COLUMNS
+    ]
+
     submissions = list(
         InstrumentRentalRequestSubmission.objects.annotate(
             status_order=Case(
@@ -524,7 +567,7 @@ def rental_requests_dashboard(request):
                 output_field=IntegerField(),
             )
         )
-        .order_by("status_order", "-date_submitted")
+        .order_by(*order_by)
         .select_related("member", "instrument", "second_choice", "third_choice", "assigned_unit",
                         "assigned_unit__member", "assigned_unit__instrument")
     )
@@ -571,6 +614,7 @@ def rental_requests_dashboard(request):
 
     return render(request, "wagtailadmin/rental_requests_dashboard.html", {
         "submissions": submissions,
+        "sort_columns": sort_columns,
         "nag_all_preview": nag_all_preview,
         "nag_all_confirm_message": nag_all_confirm_message,
     })


### PR DESCRIPTION
Column headers on the rental requests dashboard are now links that sort the table by that column. Clicking a header sorts ascending; clicking the same header again flips to descending, indicated by an arrow next to the label.

Sorting is server-side via a `?sort=` query param. The param maps through a whitelist (`RENTAL_DASHBOARD_SORTS`) to model fields, so an unknown or malformed key falls back to the existing default ordering (pending requests first, newest first) instead of erroring. Sortable columns: Member, 1st Choice, Submitted, Status, Patreon, Pledge/mo, Last charge, Patron since, Lifetime.

The header row in the template is now rendered from a `sort_columns` list built in the view, so labels and sort keys live in one place.

## Testing
Added `test_dashboard_sorting` covering the default pending-first order, ascending and descending sorts by member name, and the fallback for an unrecognized sort key. Full `RentalRequestsAdminViewTest` suite passes (26 tests).